### PR TITLE
Switch to association type that has not been removed

### DIFF
--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -19,7 +19,6 @@
 #include "DDPlanarDigi.h"
 
 #include "edm4hep/EventHeaderCollection.h"
-#include "edm4hep/MCRecoTrackerHitPlaneAssociationCollection.h"
 #include "edm4hep/SimTrackerHit.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
 
@@ -89,9 +88,8 @@ StatusCode DDPlanarDigi::initialize() {
   return StatusCode::SUCCESS;
 }
 
-std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::MCRecoTrackerHitPlaneAssociationCollection>
-DDPlanarDigi::operator()(const edm4hep::SimTrackerHitCollection& simTrackerHits,
-                         const edm4hep::EventHeaderCollection&   headers) const {
+std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::MCRecoTrackerAssociationCollection> DDPlanarDigi::operator()(
+    const edm4hep::SimTrackerHitCollection& simTrackerHits, const edm4hep::EventHeaderCollection& headers) const {
   auto seed = m_uidSvc->getUniqueID(headers[0].getEventNumber(), headers[0].getRunNumber(), this->name());
   debug() << "Using seed " << seed << " for event " << headers[0].getEventNumber() << " and run "
           << headers[0].getRunNumber() << endmsg;
@@ -101,7 +99,7 @@ DDPlanarDigi::operator()(const edm4hep::SimTrackerHitCollection& simTrackerHits,
   int nDismissedHits = 0;
 
   auto trkhitVec = edm4hep::TrackerHitPlaneCollection();
-  auto thsthcol  = edm4hep::MCRecoTrackerHitPlaneAssociationCollection();
+  auto thsthcol  = edm4hep::MCRecoTrackerAssociationCollection();
 
   std::string cellIDEncodingString = m_geoSvc->constantAsString(m_encodingStringVariable.value());
   dd4hep::DDSegmentation::BitFieldCoder bitFieldCoder(cellIDEncodingString);

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
@@ -23,7 +23,7 @@
 #include "Gaudi/Property.h"
 
 #include "edm4hep/EventHeaderCollection.h"
-#include "edm4hep/MCRecoTrackerHitPlaneAssociationCollection.h"
+#include "edm4hep/MCRecoTrackerAssociationCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
 
@@ -73,14 +73,14 @@ enum { hu = 0, hv, hT, hitE, hitsAccepted, diffu, diffv, diffT, hSize };
 
 struct DDPlanarDigi final
     : k4FWCore::MultiTransformer<
-          std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::MCRecoTrackerHitPlaneAssociationCollection>(
+          std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::MCRecoTrackerAssociationCollection>(
               const edm4hep::SimTrackerHitCollection&, const edm4hep::EventHeaderCollection&)> {
   DDPlanarDigi(const std::string& name, ISvcLocator* svcLoc);
 
   StatusCode initialize() override;
   StatusCode finalize() override;
 
-  std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::MCRecoTrackerHitPlaneAssociationCollection> operator()(
+  std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::MCRecoTrackerAssociationCollection> operator()(
       const edm4hep::SimTrackerHitCollection& simTrackerHits,
       const edm4hep::EventHeaderCollection&   headers) const override;
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Switch from TrackerHit Plane asociation to TrackerHit association, because the former has been removed from EDM4hep in [EDM4hep#331](https://github.com/key4hep/EDM4hep/pull/331)

ENDRELEASENOTES

These changes do **not** require the EDM4hep PR to be merged first!
