### PR TITLE
Fix the DDPlanarDigi algorithm to run like the processor

### DIFF
--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -23,13 +23,11 @@
 #include "edm4hep/TrackerHitPlaneCollection.h"
 
 #include "Gaudi/Accumulators/RootHistogram.h"
-#include "Gaudi/Histograming/Sink/Utils.h"
 
 #include "DD4hep/DD4hepUnits.h"
 #include "DD4hep/Detector.h"
 #include "DDSegmentation/BitFieldCoder.h"
 
-#include "TFile.h"
 #include "TMath.h"
 
 #include <fmt/format.h>
@@ -310,26 +308,4 @@ std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::MCRecoTrackerAssociation
   debug() << "Created " << nCreatedHits << " hits, " << nDismissedHits << " hits  dismissed" << endmsg;
 
   return std::make_tuple(std::move(trkhitVec), std::move(thsthcol));
-}
-
-StatusCode DDPlanarDigi::finalize() {
-  auto file = TFile::Open(m_outputFileName.value().c_str(), "UPDATE");
-
-  std::vector<const char*> names = {"hu", "hv", "hT", "hitE", "hitsAccepted", "diffu", "diffv", "diffT", "hSize"};
-
-  std::string directory = this->name();
-
-  for (size_t i = 0; i < m_histograms.size(); ++i) {
-    std::string           histName = names[i];
-    const nlohmann::json& json     = *m_histograms[i];
-
-    auto [histo, dir] =
-        Gaudi::Histograming::Sink::jsonToRootHistogram<Gaudi::Histograming::Sink::Traits<false, TH1D, 1>>(
-            directory, histName, json);
-
-    histo.Write(histName.c_str());
-  }
-
-  file->Close();
-  return StatusCode::SUCCESS;
 }

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
@@ -77,7 +77,6 @@ struct DDPlanarDigi final
   DDPlanarDigi(const std::string& name, ISvcLocator* svcLoc);
 
   StatusCode initialize() override;
-  StatusCode finalize() override;
 
   std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::MCRecoTrackerAssociationCollection> operator()(
       const edm4hep::SimTrackerHitCollection& simTrackerHits,

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
@@ -35,7 +35,6 @@
 
 #include "TRandom2.h"
 
-#include <random>
 #include <string>
 #include <vector>
 
@@ -94,7 +93,7 @@ private:
   Gaudi::Property<std::vector<float>> m_resTLayer{
       this,
       "ResolutionT",
-      {0.004},
+      {-1},
       "Resolution in the direction of t; either one per layer or one for all layers. If the single entry is negative, "
       "disable time smearing. "};
   Gaudi::Property<bool>   m_forceHitsOntoSurface{this, "ForceHitsOntoSurface", false,

--- a/k4Reco/DDPlanarDigi/options/runDDPlanarDigi.py
+++ b/k4Reco/DDPlanarDigi/options/runDDPlanarDigi.py
@@ -22,6 +22,8 @@ from Configurables import EventDataSvc
 from Configurables import DDPlanarDigi
 from Configurables import GeoSvc
 from Configurables import UniqueIDGenSvc
+from Configurables import RootHistSvc
+from Configurables import Gaudi__Histograming__Sink__Root as RootHistoSink
 import os
 
 id_service = UniqueIDGenSvc("UniqueIDGenSvc")
@@ -50,9 +52,13 @@ iosvc.output = "output_digi.root"
 #     "EventHeader",
 # ]
 
+hps = RootHistSvc("HistogramPersistencySvc")
+root_hist_svc = RootHistoSink("RootHistoSink")
+root_hist_svc.FileName = "ddplanardigi_hist.root"
+
 ApplicationMgr(TopAlg=[digi],
                EvtSel="NONE",
                EvtMax=-1,
-               ExtSvc=[EventDataSvc("EventDataSvc")],
+               ExtSvc=[EventDataSvc("EventDataSvc"), root_hist_svc],
                OutputLevel=INFO,
                )


### PR DESCRIPTION
some things I found when comparing the output histograms.

BEGINRELEASENOTES
- Change the default value for the time resolution to -1, which will mean no time smearing by default.
- Use the histogram service to save histograms instead of saving our own files (which meant that if the algorithm runs multiple time there will be multiple files, or a single one if the name is the name for all of them with the content of the last one that was saved).
- Other minor changes like removing an unnecessary header or changing `and` to `&&`.

ENDRELEASENOTES