### PR TITLE
Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,16 +34,9 @@ find_package(Gaudi REQUIRED)
 find_package(DD4hep REQUIRED)
 find_package(k4SimGeant4 REQUIRED)
 
+include(cmake/Key4hepConfig.cmake)
+
 include(GNUInstallDirs)
-
-# Set up C++ Standard
-# ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-
-if(NOT CMAKE_CXX_STANDARD MATCHES "14|17|20")
-  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
-endif()
-
 include(CTest)
 
 add_subdirectory(k4Reco)


### PR DESCRIPTION
See https://github.com/key4hep/EDM4hep/pull/359.

BEGINRELEASENOTES
- Use the Key4hepConfig flag to set the standard, compiler flags and rpath magic.

ENDRELEASENOTES