### PR TITLE
Fix steering file for Overlay Timing

### DIFF
--- a/k4Reco/Overlay/options/runOverlayTiming.py
+++ b/k4Reco/Overlay/options/runOverlayTiming.py
@@ -43,9 +43,9 @@ iosvc.Output = "output_overlay.root"
 
 overlay = OverlayTiming()
 overlay.MCParticles = ["MCParticle"]
-overlay.BackgroundMCParticleCollectionName = ["MCParticle"]
 overlay.SimTrackerHits = ["VertexBarrelCollection", "VertexEndcapCollection"]
 overlay.SimCalorimeterHits = ["HCalRingCollection"]
+overlay.BackgroundMCParticleCollectionName = "MCParticle"
 overlay.OutputSimTrackerHits = ["NewVertexBarrelCollection", "NewVertexEndcapCollection"]
 overlay.OutputSimCalorimeterHits = ["NewHCalRingCollection"]
 overlay.OutputCaloHitContributions = ["NewCaloHitCollection"]


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix the steering file for Overlay Timing: Make sure to pass a string for the MCParticle name in the background file and not a list

ENDRELEASENOTES