### PR TITLE
Move the check for the end of file before getting the next event

### DIFF
--- a/k4Reco/Overlay/components/OverlayTiming.cpp
+++ b/k4Reco/Overlay/components/OverlayTiming.cpp
@@ -221,13 +221,13 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection&         
       for (int k = 0; k < NOverlay_to_this_BX; ++k) {
         info() << "Overlaying background event " << m_bkgEvents->m_nextEntry[groupIndex] << " from group " << groupIndex
                << " to BX " << bxInTrain << endmsg;
-        auto backgroundEvent =
-            m_bkgEvents->m_rootFileReaders[groupIndex].readEvent(m_bkgEvents->m_nextEntry[groupIndex]);
-        m_bkgEvents->m_nextEntry[groupIndex]++;
         if (m_bkgEvents->m_nextEntry[groupIndex] >= m_bkgEvents->m_totalNumberOfEvents[groupIndex] &&
             !m_allowReusingBackgroundFiles) {
           throw GaudiException("No more events in background file", name(), StatusCode::FAILURE);
         }
+        auto backgroundEvent =
+            m_bkgEvents->m_rootFileReaders[groupIndex].readEvent(m_bkgEvents->m_nextEntry[groupIndex]);
+        m_bkgEvents->m_nextEntry[groupIndex]++;
         m_bkgEvents->m_nextEntry[groupIndex] %= m_bkgEvents->m_totalNumberOfEvents[groupIndex];
         auto availableCollections = backgroundEvent.getAvailableCollections();
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Move the check for the end of file before getting the next event, making it possible to run with a bacground file with the same number of events as the signal file (with the option of reusing disabled). Previously the check was happening one event too soon.

ENDRELEASENOTES