### PR TITLE
Add an option to copy CellID metadata when overlaying

### DIFF
--- a/k4Reco/Overlay/components/OverlayTiming.cpp
+++ b/k4Reco/Overlay/components/OverlayTiming.cpp
@@ -19,10 +19,14 @@
 #include "OverlayTiming.h"
 #include <GaudiKernel/MsgStream.h>
 
-#include "podio/Frame.h"
+#include "podio/FrameCategories.h"
 
+#include "edm4hep/CaloHitContributionCollection.h"
 #include "edm4hep/Constants.h"
-#include "edm4hep/MutableCaloHitContribution.h"
+#include "edm4hep/EventHeaderCollection.h"
+#include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/SimCalorimeterHitCollection.h"
+#include "edm4hep/SimTrackerHitCollection.h"
 
 #include "k4FWCore/MetadataUtils.h"
 
@@ -30,6 +34,8 @@
 
 #include <limits>
 #include <random>
+#include <utility>
+#include <vector>
 
 template <typename T> inline float time_of_flight(const T& pos) {
   // Returns the time of flight to the radius in ns
@@ -387,12 +393,13 @@ StatusCode OverlayTiming::finalize() {
          {std::make_pair(inputLocations("SimTrackerHits"), outputLocations("OutputSimTrackerHits")),
           std::make_pair(inputLocations("SimCalorimeterHits"), outputLocations("OutputSimCalorimeterHits"))}) {
       for (size_t i = 0; i < input.size(); ++i) {
-        auto name  = input[i];
-        auto value = k4FWCore::getParameter<std::string>(name + "__" + edm4hep::labels::CellIDEncoding, this);
+        auto value = k4FWCore::getParameter<std::string>(
+            podio::collMetadataParamName(input[i], edm4hep::labels::CellIDEncoding), this);
         if (value.has_value()) {
-          k4FWCore::putParameter(output[i] + "__" + edm4hep::labels::CellIDEncoding, value.value(), this);
+          k4FWCore::putParameter(podio::collMetadataParamName(output[i], edm4hep::labels::CellIDEncoding),
+                                 value.value(), this);
         } else {
-          warning() << "No metadata found for " << name << " when copying CellID metadata was requested" << endmsg;
+          warning() << "No metadata found for " << input[i] << " when copying CellID metadata was requested" << endmsg;
         }
       }
     }

--- a/k4Reco/Overlay/components/OverlayTiming.cpp
+++ b/k4Reco/Overlay/components/OverlayTiming.cpp
@@ -392,7 +392,7 @@ StatusCode OverlayTiming::finalize() {
         if (value.has_value()) {
           k4FWCore::putParameter(output[i] + "__" + edm4hep::labels::CellIDEncoding, value.value(), this);
         } else {
-          warning() << "No metadata found for " << name << endmsg;
+          warning() << "No metadata found for " << name << " when copying CellID metadata was requested" << endmsg;
         }
       }
     }

--- a/k4Reco/Overlay/components/OverlayTiming.cpp
+++ b/k4Reco/Overlay/components/OverlayTiming.cpp
@@ -384,8 +384,8 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection&         
 StatusCode OverlayTiming::finalize() {
   if (m_copyCellIDMetadata) {
     for (auto& [input, output] :
-         {std::make_pair(inputLocations(SIMTRACKERHIT_INDEX_POSITION), outputLocations("OutputSimTrackerHits")),
-          std::make_pair(inputLocations(SIMCALOHIT_INDEX_POSITION), outputLocations("OutputSimCalorimeterHits"))}) {
+         {std::make_pair(inputLocations("SimTrackerHits"), outputLocations("OutputSimTrackerHits")),
+          std::make_pair(inputLocations("SimCalorimeterHits"), outputLocations("OutputSimCalorimeterHits"))}) {
       for (size_t i = 0; i < input.size(); ++i) {
         auto name  = input[i];
         auto value = k4FWCore::getParameter<std::string>(name + "__" + edm4hep::labels::CellIDEncoding, this);

--- a/k4Reco/Overlay/components/OverlayTiming.h
+++ b/k4Reco/Overlay/components/OverlayTiming.h
@@ -94,6 +94,7 @@ struct OverlayTiming : public k4FWCore::MultiTransformer<retType(
   template <typename T> void overlayCollection(std::string collName, const podio::CollectionBase& inColl);
 
   virtual StatusCode initialize() final;
+  virtual StatusCode finalize() final;
 
   retType virtual operator()(
       const edm4hep::EventHeaderCollection& headers, const edm4hep::MCParticleCollection& mcParticles,
@@ -140,6 +141,9 @@ private:
       this, "TimeWindows", std::map<std::string, std::vector<float>>(), "Time windows for the different collections"};
   Gaudi::Property<bool> m_allowReusingBackgroundFiles{
       this, "AllowReusingBackgroundFiles", false, "If true the same background file can be used for the same event"};
+  Gaudi::Property<bool> m_copyCellIDMetadata{this, "CopyCellIDMetadata", false,
+                                             "If metadata is found in the signal file, copy it to the output file, "
+                                             "replacing the old names with the new names"};
 
   // Gaudi::Property<int> m_maxCachedFrames{
   //   this, "MaxCachedFrames", 0, "Maximum number of frames cached from background files"};

--- a/k4Reco/Overlay/components/OverlayTiming.h
+++ b/k4Reco/Overlay/components/OverlayTiming.h
@@ -48,7 +48,10 @@
 #include "Gaudi/Parsers/Factory.h"
 #include "Gaudi/Property.h"
 
+#include <map>
 #include <random>
+#include <string>
+#include <vector>
 
 struct EventHolder {
   std::vector<std::vector<std::string>> m_fileNames;

--- a/k4Reco/Overlay/options/runOverlayTiming.py
+++ b/k4Reco/Overlay/options/runOverlayTiming.py
@@ -57,6 +57,7 @@ overlay.BackgroundFileNames = [
       ["background_group2_1.root"],
 ]
 overlay.TimeWindows = {"MCParticle": [0, 23.5], "VertexBarrelCollection": [0, 23.5], "VertexEndcapCollection": [0, 23.5], "HCalRingCollection": [0, 23.5]}
+overlay.CopyCellIDMetadata = True
 
 ApplicationMgr(TopAlg=[overlay],
                EvtSel="NONE",

--- a/k4Reco/Overlay/options/runOverlayTiming.py
+++ b/k4Reco/Overlay/options/runOverlayTiming.py
@@ -59,6 +59,9 @@ overlay.BackgroundFileNames = [
 overlay.TimeWindows = {"MCParticle": [0, 23.5], "VertexBarrelCollection": [0, 23.5], "VertexEndcapCollection": [0, 23.5], "HCalRingCollection": [0, 23.5]}
 overlay.CopyCellIDMetadata = True
 
+# In case the original collections should be dropped
+# iosvc.outputCommands = ["drop MCParticles", "drop VertexBarrelCollection"]
+
 ApplicationMgr(TopAlg=[overlay],
                EvtSel="NONE",
                EvtMax=10,


### PR DESCRIPTION
BEGINRELEASENOTES
- Add an option to copy CellID metadata when overlaying, so that the new collections can be equivalent to the old ones. 

ENDRELEASENOTES

For example in the Marlin wrapper even if renaming the new collections to the old names, the wrapper will look for metadata using the new names.