### PR TITLE
Find DD4hep first to avoid python version clashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,10 +29,10 @@ set(PACKAGE_VERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}.${PACKAGE
 
 SET(CMAKE_CXX_FLAGS "-fPIC -Wall -Wextra -Wpedantic ${CMAKE_CXX_FLAGS}")
 
+find_package(DD4hep REQUIRED)
 find_package(EDM4HEP REQUIRED)
 find_package(Gaudi REQUIRED)
 find_package(k4FWCore REQUIRED)
-find_package(DD4hep REQUIRED)
 find_package(ROOT REQUIRED COMPONENTS RIO Tree)
 find_package(k4SimGeant4 REQUIRED)
 


### PR DESCRIPTION
DD4hep has to be found pretty much first for CMake because it is the one that requires an exact version of python. However, if anything else (e.g. Boost via Gaudi) finds another version of python (typically a newer one from the underlying system) then this version will be cached and the check in the DD4hep cmake configuration will fail.

Just ran into this on Ubuntu 24. See also https://github.com/key4hep/k4GaudiPandora/pull/8

BEGINRELEASENOTES
- Make sure to find DD4hep first during CMake configuration to avoid running into issues with different python versions.

ENDRELEASENOTES
