### PR TITLE
Set the time for SimTrackerHits and CaloHitContributions from background in the Overlay algorithm

### DIFF
--- a/k4Reco/Overlay/components/OverlayTiming.cpp
+++ b/k4Reco/Overlay/components/OverlayTiming.cpp
@@ -311,6 +311,7 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection&         
                 continue;
               auto nhit = elem.clone(false);
               nhit.setOverlay(true);
+              nhit.setTime(elem.getTime() + timeOffset);
               nhit.setParticle(oparticles[oldToNewMap[elem.getParticle().getObjectID().index]]);
               ocoll->push_back(nhit);
             }
@@ -344,6 +345,7 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection&         
                   // TODO: Make sure a contribution is not added twice
                   auto newcontrib = contrib.clone(false);
                   newcontrib.setParticle(oparticles[oldToNewMap[contrib.getParticle().getObjectID().index]]);
+                  newcontrib.setTime(contrib.getTime() + timeOffset);
                   calhit.addToContributions(newcontrib);
                   calHitContribs.push_back(newcontrib);
                 }
@@ -362,6 +364,7 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection&         
                   // TODO: Make sure a contribution is not added twice
                   auto newcontrib = contrib.clone(false);
                   newcontrib.setParticle(oparticles[oldToNewMap[contrib.getParticle().getObjectID().index]]);
+                  newcontrib.setTime(contrib.getTime() + timeOffset);
                   calhit.addToContributions(newcontrib);
                   calHitContribs.push_back(newcontrib);
                 }


### PR DESCRIPTION
Fix #14.

After this change the times will be the following:
- For signal events, for MCParticles (all), SimTrackerHits (after cuts) and CaloHitContributions (after cuts) the time is kept as it is
- For background events, the time is the original plus an offset for the three types above.

This now means that since the SimCalorimeterHits can have contributions that come from signal and background at the same time, they can have times corresponding to signal and background.


BEGINRELEASENOTES
- Set the time for SimTrackerHits and CaloHitContributions from background in the Overlay algorithm

ENDRELEASENOTES