### PR TITLE
Fix setting the time for tracker hits in Overlay

### DIFF
--- a/k4Reco/Overlay/components/OverlayTiming.cpp
+++ b/k4Reco/Overlay/components/OverlayTiming.cpp
@@ -302,19 +302,17 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection&         
             continue;
           }
           auto& ocoll = osimTrackerHits[i];
-          if (std::abs(timeOffset) < std::numeric_limits<float>::epsilon()) {
-            for (const auto&& simTrackerHit : backgroundEvent.get<edm4hep::SimTrackerHitCollection>(name)) {
-              const float tof = time_of_flight(simTrackerHit.getPosition());
+          for (const auto&& simTrackerHit : backgroundEvent.get<edm4hep::SimTrackerHitCollection>(name)) {
+            const float tof = time_of_flight(simTrackerHit.getPosition());
 
-              if (!((simTrackerHit.getTime() + timeOffset > this_start + tof) &&
-                    (simTrackerHit.getTime() + timeOffset < this_stop + tof)))
-                continue;
-              auto nhit = simTrackerHit.clone(false);
-              nhit.setOverlay(true);
-              nhit.setTime(simTrackerHit.getTime() + timeOffset);
-              nhit.setParticle(oparticles[oldToNewMap[simTrackerHit.getParticle().getObjectID().index]]);
-              ocoll->push_back(nhit);
-            }
+            if (!((simTrackerHit.getTime() + timeOffset > this_start + tof) &&
+                  (simTrackerHit.getTime() + timeOffset < this_stop + tof)))
+              continue;
+            auto nhit = simTrackerHit.clone(false);
+            nhit.setOverlay(true);
+            nhit.setTime(simTrackerHit.getTime() + timeOffset);
+            nhit.setParticle(oparticles[oldToNewMap[simTrackerHit.getParticle().getObjectID().index]]);
+            ocoll->push_back(nhit);
           }
         }
 

--- a/k4Reco/Overlay/components/OverlayTiming.cpp
+++ b/k4Reco/Overlay/components/OverlayTiming.cpp
@@ -32,7 +32,6 @@
 
 #include <TMath.h>
 
-#include <limits>
 #include <random>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
It was not being set for any bunch that wasn't the signal bunch (time offset = 0). Coming from https://github.com/iLCSoft/Overlay/blob/master/src/OverlayTiming.cc#L709, the || in the condition was lost when removing the check for TPC that was present in the original version. How it worked there was to overlay if either there is no time offset or it is not a TPC hit.

Fix the issue reported in https://github.com/key4hep/k4Reco/issues/14#issuecomment-2619428292

BEGINRELEASENOTES
- Fix setting the time for tracker hits in Overlay

ENDRELEASENOTES

<img src="https://github.com/user-attachments/assets/d9414b45-b1a1-45b0-b462-022aaddc2c2b" width="350">

with background1 being the first overlayed background event (one background event per bunch)
