### PR TITLE
Improve failing when retrieving GeoSvc in DDPlanarDigi

### DIFF
--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -66,11 +66,9 @@ DDPlanarDigi::DDPlanarDigi(const std::string& name, ISvcLocator* svcLoc)
       new Gaudi::Accumulators::StaticRootHistogram<1>{this, "hitE", "hitEnergy in keV", {1000, 0, 200}});
   m_histograms[hitsAccepted].reset(new Gaudi::Accumulators::StaticRootHistogram<1>{
       this, "hitsAccepted", "Fraction of accepted hits [%]", {201, 0, 100.5}});
-
 }
 
 StatusCode DDPlanarDigi::initialize() {
-
   m_geoSvc = serviceLocator()->service(m_geoSvcName);
   if (!m_geoSvc) {
     error() << "Unable to retrieve the GeoSvc" << endmsg;

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -67,10 +67,16 @@ DDPlanarDigi::DDPlanarDigi(const std::string& name, ISvcLocator* svcLoc)
   m_histograms[hitsAccepted].reset(new Gaudi::Accumulators::StaticRootHistogram<1>{
       this, "hitsAccepted", "Fraction of accepted hits [%]", {201, 0, 100.5}});
 
-  m_geoSvc = serviceLocator()->service(m_geoSvcName);
 }
 
 StatusCode DDPlanarDigi::initialize() {
+
+  m_geoSvc = serviceLocator()->service(m_geoSvcName);
+  if (!m_geoSvc) {
+    error() << "Unable to retrieve the GeoSvc" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
   const auto detector = m_geoSvc->getDetector();
 
   const auto         surfMan = detector->extension<dd4hep::rec::SurfaceManager>();


### PR DESCRIPTION
Before, if `GeoSvc` is not present it fails with a very cryptic message:
```
ObjectExtensions::extension ERROR The object has no extension of type AACD2D795D870AB9.
DDPlanarDigi        FATAL Standard std::exception is caught in sysInitialize
DDPlanarDigi        ERROR ObjectExtensions::extension: The object has no extension of type AACD2D795D870AB9.
```
Now, it will print a proper error message


BEGINRELEASENOTES
- Improve failing when retrieving GeoSvc in DDPlanarDigi

ENDRELEASENOTES