### PR TITLE
Use std::uint64_t with cellIDs instead of converting to int in DDPlanarDigi

### DIFF
--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -128,7 +128,7 @@ std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::TrackerHitSimTrackerHitL
     }
 
     const dd4hep::rec::ISurface* surf  = sI->second;
-    int                         layer = bitFieldCoder.get(cellID, "layer");
+    int                          layer = bitFieldCoder.get(cellID, "layer");
 
     dd4hep::rec::Vector3D oldPos(hit.getPosition()[0], hit.getPosition()[1], hit.getPosition()[2]);
     dd4hep::rec::Vector3D newPos;

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -118,17 +118,17 @@ std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::TrackerHitSimTrackerHitL
       continue;
     }
 
-    const auto cellID0 = hit.getCellID();
+    const std::uint64_t cellID = hit.getCellID();
 
     // get the measurement surface for this hit using the CellID
-    dd4hep::rec::SurfaceMap::const_iterator sI = surfaceMap->find(cellID0);
+    dd4hep::rec::SurfaceMap::const_iterator sI = surfaceMap->find(cellID);
 
     if (sI == surfaceMap->end()) {
-      throw std::runtime_error(fmt::format("DDPlanarDigi::processEvent(): no surface found for cellID : {}", cellID0));
+      throw std::runtime_error(fmt::format("DDPlanarDigi::processEvent(): no surface found for cellID : {}", cellID));
     }
 
     const dd4hep::rec::ISurface* surf  = sI->second;
-    int                          layer = bitFieldCoder.get(cellID0, "layer");
+    int                         layer = bitFieldCoder.get(cellID, "layer");
 
     dd4hep::rec::Vector3D oldPos(hit.getPosition()[0], hit.getPosition()[1], hit.getPosition()[2]);
     dd4hep::rec::Vector3D newPos;
@@ -268,7 +268,7 @@ std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::TrackerHitSimTrackerHitL
 
     auto trkHit = trkhitVec.create();
 
-    trkHit.setCellID(cellID0);
+    trkHit.setCellID(cellID);
 
     trkHit.setPosition(newPos.const_array());
     trkHit.setTime(hitT);

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -118,7 +118,7 @@ std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::TrackerHitSimTrackerHitL
       continue;
     }
 
-    const int cellID0 = hit.getCellID();
+    const auto cellID0 = hit.getCellID();
 
     // get the measurement surface for this hit using the CellID
     dd4hep::rec::SurfaceMap::const_iterator sI = surfaceMap->find(cellID0);


### PR DESCRIPTION
BEGINRELEASENOTES
- Use auto std::uint64_t with cellIDs instead of converting to int in DDPlanarDigi

ENDRELEASENOTES

One of the remnants of the original, where int was used: https://github.com/iLCSoft/MarlinTrkProcessors/blob/master/source/Digitisers/src/DDPlanarDigiProcessor.cc#L224