### PR TITLE
DDPlanarDigi: Add an option to select only some number of bits in the Cell IDs

### DIFF
--- a/k4Reco/DDPlanarDigi/README.md
+++ b/k4Reco/DDPlanarDigi/README.md
@@ -1,0 +1,14 @@
+This is a port of the DDPlanarDigi processor. The original header and source
+files can be found in
+https://github.com/iLCSoft/MarlinTrkProcessors/blob/master/source/Digitisers/include/DDPlanarDigiProcessor.h
+and
+https://github.com/iLCSoft/MarlinTrkProcessors/blob/master/source/Digitisers/src/DDPlanarDigiProcessor.cc
+
+It's very similar to the original one. The (possibly incomplete) list of differences would be:
+- Different random number generator and seed (makes it impossible to compare on
+  an event-by-event level). GSL was used in the processor, TRandom3 is being
+  used in the algorithm use the UniqueIDGenSvc to seed each event.
+- The detector instance from DD4hep is obtained with GeoSvc in the algorithm
+- The algorithm has an extra option to only use a certain number of bits for the
+  cell IDs that are obtained from the hits (see
+  https://github.com/key4hep/k4Reco/pull/25)

--- a/k4Reco/DDPlanarDigi/README.md
+++ b/k4Reco/DDPlanarDigi/README.md
@@ -1,3 +1,21 @@
+<!--
+Copyright (c) 2020-2024 Key4hep-Project.
+
+This file is part of Key4hep.
+See https://key4hep.github.io/key4hep-doc/ for further info.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
 This is a port of the DDPlanarDigi processor. The original header and source
 files can be found in
 https://github.com/iLCSoft/MarlinTrkProcessors/blob/master/source/Digitisers/include/DDPlanarDigiProcessor.h

--- a/k4Reco/DDPlanarDigi/README.md
+++ b/k4Reco/DDPlanarDigi/README.md
@@ -7,8 +7,8 @@ https://github.com/iLCSoft/MarlinTrkProcessors/blob/master/source/Digitisers/src
 It's very similar to the original one. The (possibly incomplete) list of differences would be:
 - Different random number generator and seed (makes it impossible to compare on
   an event-by-event level). GSL was used in the processor, TRandom3 is being
-  used in the algorithm use the UniqueIDGenSvc to seed each event.
-- The detector instance from DD4hep is obtained with GeoSvc in the algorithm
+  used in the algorithm that also uses the UniqueIDGenSvc to seed each event.
+- The detector instance from DD4hep is obtained with GeoSvc in the algorithm.
 - The algorithm has an extra option to only use a certain number of bits for the
   cell IDs that are obtained from the hits (see
-  https://github.com/key4hep/k4Reco/pull/25)
+  https://github.com/key4hep/k4Reco/pull/25).

--- a/k4Reco/DDPlanarDigi/README.md
+++ b/k4Reco/DDPlanarDigi/README.md
@@ -27,6 +27,6 @@ It's very similar to the original one. The (possibly incomplete) list of differe
   an event-by-event level). GSL was used in the processor, TRandom3 is being
   used in the algorithm that also uses the UniqueIDGenSvc to seed each event.
 - The detector instance from DD4hep is obtained with GeoSvc in the algorithm.
-- The algorithm has an extra option to only use a certain number of bits for the
-  cell IDs that are obtained from the hits (see
+- The algorithm has an extra option (`CellIDBits`) to only use a certain number
+  of bits for the cell IDs that are obtained from the hits (see
   https://github.com/key4hep/k4Reco/pull/25).

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -88,6 +88,10 @@ StatusCode DDPlanarDigi::initialize() {
   // Get and store the name for a debug message later
   (void)this->getProperty("SimTrackerHitCollectionName", m_collName);
 
+  if (m_cellIDBits != 64) {
+    m_mask = (static_cast<std::uint64_t>(1) << m_cellIDBits) - 1;
+  }
+
   return StatusCode::SUCCESS;
 }
 
@@ -118,7 +122,7 @@ std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::TrackerHitSimTrackerHitL
       continue;
     }
 
-    const std::uint64_t cellID = hit.getCellID();
+    const std::uint64_t cellID = hit.getCellID() & m_mask;
 
     // get the measurement surface for this hit using the CellID
     dd4hep::rec::SurfaceMap::const_iterator sI = surfaceMap->find(cellID);

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
@@ -123,8 +123,8 @@ private:
       this, "EncodingStringParameterName", "GlobalTrackerReadoutID",
       "The name of the DD4hep constant that contains the Encoding string for tracking detectors"};
   Gaudi::Property<std::string> m_geoSvcName{this, "GeoSvcName", "GeoSvc", "The name of the GeoSvc instance"};
-  Gaudi::Property<int> m_maxTries{this, "MaxTries", 10, "Maximum number of tries to find a valid surface for a hit"};
-
+  Gaudi::Property<int>    m_maxTries{this, "MaxTries", 10, "Maximum number of tries to find a valid surface for a hit"};
+  Gaudi::Property<size_t> m_cellIDBits{this, "CellIDBits", 64, "Number of bits to use for the cellID of the hits"};
   const dd4hep::rec::SurfaceMap*                                                  surfaceMap;
   std::array<std::unique_ptr<Gaudi::Accumulators::StaticRootHistogram<1>>, hSize> m_histograms;
   std::string                                                                     m_collName;
@@ -132,6 +132,8 @@ private:
   inline static thread_local TRandom2 m_engine;
   SmartIF<IGeoSvc>                    m_geoSvc;
   SmartIF<IUniqueIDGenSvc>            m_uidSvc;
+
+  std::uint64_t m_mask{static_cast<std::uint64_t>(-1)};
 };
 
 DECLARE_COMPONENT(DDPlanarDigi)


### PR DESCRIPTION
BEGINRELEASENOTES
- DDPlanarDigi: Add the option "CellIDBits" to select only some number of bits in the Cell IDs. It can be used for detectors that have segmentation. Note that for this to work, the segmentation bits have to be at the end of the cell ID number, since only the first N bits will be used.

ENDRELEASENOTES

See the discussion in https://github.com/key4hep/k4Reco/issues/22