### PR TITLE
replace removed `IOSvc` properties `input` and `output`

### DIFF
--- a/k4Reco/DDPlanarDigi/options/runDDPlanarDigi.py
+++ b/k4Reco/DDPlanarDigi/options/runDDPlanarDigi.py
@@ -43,8 +43,8 @@ digi.SimTrkHitRelCollection = ["VXDTrackerHitRelations"]
 digi.TrackerHitCollectionName = ["VXDTrackerHits"]
 
 iosvc = IOSvc()
-iosvc.input = "input.root"
-iosvc.output = "output_digi.root"
+iosvc.Input = "input.root"
+iosvc.Output = "output_digi.root"
 
 # inp.collections = [
 #     "VertexBarrelCollection",

--- a/k4Reco/Overlay/options/runOverlayTiming.py
+++ b/k4Reco/Overlay/options/runOverlayTiming.py
@@ -29,7 +29,6 @@ id_service = UniqueIDGenSvc("UniqueIDGenSvc")
 eds = EventDataSvc("EventDataSvc")
 
 iosvc = IOSvc()
-# iosvc.input = "input.root"
 iosvc.Input = "input.root"
 iosvc.Output = "output_overlay.root"
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Use the properties `Input` and `Output` with `IOSvc` instead of the deprecated `input` and `output`.

ENDRELEASENOTES


The  `IOSvc` properties `input` and `output` were deprecated and removed in key4hep/k4FWCore#297.