### PR TITLE
Emulating detector efficiency in DDPlanarDigi

### DIFF
--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -119,7 +119,6 @@ std::tuple<edm4hep::TrackerHitPlaneCollection, edm4hep::TrackerHitSimTrackerHitL
   int nSimHits = simTrackerHits.size();
   debug() << "Processing collection " << m_collName << " with " << simTrackerHits.size() << " hits ... " << endmsg;
 
-
   for (const auto& hit : simTrackerHits) {
     ++(*m_histograms[hitE])[hit.getEDep() * (dd4hep::GeV / dd4hep::keV)];
 

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
@@ -105,6 +105,8 @@ private:
       {-1},
       "Resolution in the direction of t; either one per layer or one for all layers. If the single entry is negative, "
       "disable time smearing. "};
+  Gaudi::Property<double> m_efficiency{
+      this, "Efficiency", 1.00, "Efficiency of the chamber to detect the charged particle"};    
   Gaudi::Property<bool>   m_forceHitsOntoSurface{this, "ForceHitsOntoSurface", false,
                                                "Project hits onto the surfoce in case they are not yet on the surface"};
   Gaudi::Property<double> m_minEnergy{this, "MinEnergy", 0.0, "Minimum energy (GeV) of SimTrackerHit to be digitized"};


### PR DESCRIPTION
BEGINRELEASENOTES
- Defining a new property for the detector efficiency in DDPlanarDigi, which can take values from 0.0 to 1.0, and  set by default to 1.0
- Throwing an error if the user put value > 1.0
- Inspired from #17 

ENDRELEASENOTES
