### PR TITLE
Don't use `thread_local` for "mutable" members

### DIFF
--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -101,7 +101,7 @@ DDPlanarDigi::operator()(const edm4hep::SimTrackerHitCollection& simTrackerHits,
   auto seed = m_uidSvc->getUniqueID(headers[0].getEventNumber(), headers[0].getRunNumber(), this->name());
   debug() << "Using seed " << seed << " for event " << headers[0].getEventNumber() << " and run "
           << headers[0].getRunNumber() << endmsg;
-  m_engine.SetSeed(seed);
+  auto rng_engine = TRandom2(seed);
 
   int nCreatedHits = 0;
   int nDismissedHits = 0;
@@ -167,7 +167,7 @@ DDPlanarDigi::operator()(const edm4hep::SimTrackerHitCollection& simTrackerHits,
     if (m_resTLayer.size() && m_resTLayer[0] > 0) {
       float resT = m_resTLayer.size() > 1 ? m_resTLayer[layer] : m_resTLayer[0];
 
-      double tSmear = resT > 0 ? m_engine.Gaus(0, resT) : 0;
+      double tSmear = resT > 0 ? rng_engine.Gaus(0, resT) : 0;
       ++(*m_histograms[hT])[resT > 0 ? tSmear / resT : 0];
       ++(*m_histograms[diffT])[tSmear];
 
@@ -217,8 +217,8 @@ DDPlanarDigi::operator()(const edm4hep::SimTrackerHitCollection& simTrackerHits,
       // if( tries > 0 ) debug() << "retry smearing for " <<  cellid_decoder( hit ).valueString() << " : retries " <<
       // tries << endmsg;
 
-      double uSmear = m_engine.Gaus(0, resU);
-      double vSmear = m_engine.Gaus(0, resV);
+      double uSmear = rng_engine.Gaus(0, resU);
+      double vSmear = rng_engine.Gaus(0, resV);
 
       dd4hep::rec::Vector3D newPosTmp;
       if (m_isStrip) {

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
@@ -129,7 +129,6 @@ private:
   std::array<std::unique_ptr<Gaudi::Accumulators::StaticRootHistogram<1>>, hSize> m_histograms;
   std::string m_collName;
 
-  inline static thread_local TRandom2 m_engine;
   SmartIF<IGeoSvc> m_geoSvc;
   SmartIF<IUniqueIDGenSvc> m_uidSvc;
 

--- a/k4Reco/Overlay/components/OverlayTiming.cpp
+++ b/k4Reco/Overlay/components/OverlayTiming.cpp
@@ -184,19 +184,20 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection& headers,
     }
   }
 
+  auto physBX = m_physBX.value();
   // Iterate over each group of files and parameters
   for (size_t groupIndex = 0; groupIndex < m_bkgEvents->size(); groupIndex++) {
     if (m_randomBX) {
-      m_physBX = std::uniform_int_distribution<int>(0, m_NBunchTrain - 1)(rng_engine);
-      debug() << "Physics Event was placed in the " << m_physBX << " bunch crossing!" << endmsg;
+      physBX = std::uniform_int_distribution<int>(0, m_NBunchTrain - 1)(rng_engine);
+      debug() << "Physics Event was placed in the " << physBX << " bunch crossing!" << endmsg;
     }
 
     // define a permutation for the events to overlay -- the physics event is per definition at position 0
     std::vector<int> permutation;
 
     // Permutation has negative values and the last one is 0
-    // if (!m_randomBX) then m_physBX (default = 1)
-    for (int i = -(m_physBX - 1); i < m_NBunchTrain - (m_physBX - 1); ++i) {
+    // if (!m_randomBX) then physBX (default = 1)
+    for (int i = -(physBX - 1); i < m_NBunchTrain - (physBX - 1); ++i) {
       permutation.push_back(i);
     }
     std::shuffle(permutation.begin(), permutation.end(), rng_engine);
@@ -225,7 +226,7 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection& headers,
         NOverlay_to_this_BX = m_Noverlay[groupIndex];
       }
 
-      debug() << "Will overlay " << NOverlay_to_this_BX << " events to BX number " << BX_number_in_train + m_physBX
+      debug() << "Will overlay " << NOverlay_to_this_BX << " events to BX number " << BX_number_in_train + physBX
               << endmsg;
 
       for (int k = 0; k < NOverlay_to_this_BX; ++k) {
@@ -298,7 +299,7 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection& headers,
           }
           const auto [this_start, this_stop] = define_time_windows(name);
           // There are only contributions to the readout if the hits are in the integration window
-          if (this_stop <= (BX_number_in_train - m_physBX) * m_deltaT) {
+          if (this_stop <= (BX_number_in_train - physBX) * m_deltaT) {
             info() << "Skipping collection " << name << " as it is not in the integration window" << endmsg;
             continue;
           }
@@ -326,7 +327,7 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection& headers,
           }
           const auto [this_start, this_stop] = define_time_windows(name);
           // There are only contributions to the readout if the hits are in the integration window
-          if (this_stop <= (BX_number_in_train - m_physBX) * m_deltaT) {
+          if (this_stop <= (BX_number_in_train - physBX) * m_deltaT) {
             info() << "Skipping collection " << name << " as it is not in the integration window" << endmsg;
             continue;
           }

--- a/k4Reco/Overlay/components/OverlayTiming.cpp
+++ b/k4Reco/Overlay/components/OverlayTiming.cpp
@@ -67,7 +67,7 @@ StatusCode OverlayTiming::initialize() {
   //   inputFiles = m_inputFileNames;
   // }
   // TODO:: shuffle input files
-  // std::shuffle(inputFiles.begin(), inputFiles.end(), m_engine);
+  // std::shuffle(inputFiles.begin(), inputFiles.end(), rng_engine);
 
   m_bkgEvents = make_unique<EventHolder>(inputFiles);
   for (auto& val : m_bkgEvents->m_totalNumberOfEvents) {
@@ -109,7 +109,7 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection& headers,
                                   const std::vector<const edm4hep::SimTrackerHitCollection*>& simTrackerHits,
                                   const std::vector<const edm4hep::SimCalorimeterHitCollection*>& simCaloHits) const {
   const auto seed = m_uidSvc->getUniqueID(headers[0].getEventNumber(), headers[0].getRunNumber(), this->name());
-  m_engine.seed(seed);
+  auto rng_engine = std::mt19937(seed);
 
   // Output collections
   auto oparticles = edm4hep::MCParticleCollection();
@@ -187,7 +187,7 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection& headers,
   // Iterate over each group of files and parameters
   for (size_t groupIndex = 0; groupIndex < m_bkgEvents->size(); groupIndex++) {
     if (m_randomBX) {
-      m_physBX = std::uniform_int_distribution<int>(0, m_NBunchTrain - 1)(m_engine);
+      m_physBX = std::uniform_int_distribution<int>(0, m_NBunchTrain - 1)(rng_engine);
       debug() << "Physics Event was placed in the " << m_physBX << " bunch crossing!" << endmsg;
     }
 
@@ -199,7 +199,7 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection& headers,
     for (int i = -(m_physBX - 1); i < m_NBunchTrain - (m_physBX - 1); ++i) {
       permutation.push_back(i);
     }
-    std::shuffle(permutation.begin(), permutation.end(), m_engine);
+    std::shuffle(permutation.begin(), permutation.end(), rng_engine);
 
     // TODO: Check that there is anything to overlay
 
@@ -220,7 +220,7 @@ retType OverlayTiming::operator()(const edm4hep::EventHeaderCollection& headers,
       int NOverlay_to_this_BX = 0;
 
       if (m_Poisson[groupIndex]) {
-        NOverlay_to_this_BX = std::poisson_distribution<>(m_Noverlay[groupIndex])(m_engine);
+        NOverlay_to_this_BX = std::poisson_distribution<>(m_Noverlay[groupIndex])(rng_engine);
       } else {
         NOverlay_to_this_BX = m_Noverlay[groupIndex];
       }

--- a/k4Reco/Overlay/components/OverlayTiming.h
+++ b/k4Reco/Overlay/components/OverlayTiming.h
@@ -153,6 +153,5 @@ private:
   //   this, "MaxCachedFrames", 0, "Maximum number of frames cached from background files"};
 
 private:
-  inline static thread_local std::mt19937 m_engine;
   SmartIF<IUniqueIDGenSvc> m_uidSvc;
 };

--- a/k4Reco/Overlay/components/OverlayTiming.h
+++ b/k4Reco/Overlay/components/OverlayTiming.h
@@ -114,7 +114,7 @@ private:
 
   Gaudi::Property<bool> m_randomBX{this, "RandomBx", false,
                                    "Place the physics event at an random position in the train: overrides PhysicsBX"};
-  mutable Gaudi::Property<int> m_physBX{this, "PhysicsBX", 1, "Number of the Bunch crossing of the physics event"};
+  Gaudi::Property<int> m_physBX{this, "PhysicsBX", 1, "Number of the Bunch crossing of the physics event"};
   Gaudi::Property<int> m_NBunchTrain{this, "NBunchtrain", 1, "Number of bunches in a bunch train"};
   // Gaudi::Property<int>         m_startWithBackgroundFile{this, "StartBackgroundFileIndex", -1,
   //                                                "Which background file to startWith"};


### PR DESCRIPTION
BEGINRELEASENOTES
- Change PRNGs from `thread_local static` members to execution-local variables
- Remove `mutable` and don't mutate "PhysicsBX" property during execution

ENDRELEASENOTES

As discussed in https://github.com/key4hep/k4RecTracker/pull/52 `thread_local`  are quite error prone and should be used only when needed. Here technically they are fine, since the variable is "reset" on each execution. But it's also possible to not use `thread_local`. Also it doesn't set an example of using `thread_local` as a workaround for `const`ness of algorithm's `execute`/`opertor()`.

Another thing was marking a property `mutable` and mutating in execution. `mutable` should be used only when other mechanism ensures it's thread-safe. As far as I can say there was no other mechanism and I think property isn't thread-safe by default (at least couldn't figure it out from the source code or usage example in Gaudi)

@atolosadelgado 
