### PR TITLE
Rename SimTrackerHitCollectionName to SimTrackHitCollectionName in DDPlanarDigi, because this is the original input name

### DIFF
--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.cpp
@@ -36,7 +36,7 @@
 DDPlanarDigi::DDPlanarDigi(const std::string& name, ISvcLocator* svcLoc)
     : MultiTransformer(name, svcLoc,
                        {
-                           KeyValues("SimTrackerHitCollectionName", {"SimTrackerHits"}),
+                           KeyValues("SimTrackHitCollectionName", {"SimTrackerHits"}),
                            KeyValues("HeaderName", {"EventHeader"}),
                        },
                        {KeyValues("TrackerHitCollectionName", {"VTXTrackerHits"}),
@@ -86,7 +86,7 @@ StatusCode DDPlanarDigi::initialize() {
   }
 
   // Get and store the name for a debug message later
-  (void)this->getProperty("SimTrackerHitCollectionName", m_collName);
+  (void)this->getProperty("SimTrackHitCollectionName", m_collName);
 
   if (m_cellIDBits != 64) {
     m_mask = (static_cast<std::uint64_t>(1) << m_cellIDBits) - 1;

--- a/k4Reco/DDPlanarDigi/options/runDDPlanarDigi.py
+++ b/k4Reco/DDPlanarDigi/options/runDDPlanarDigi.py
@@ -38,7 +38,10 @@ digi.SubDetectorName = "Vertex"
 digi.IsStrip = False
 digi.ResolutionU = [0.003, 0.003, 0.003, 0.003, 0.003, 0.003]
 digi.ResolutionV = [0.003, 0.003, 0.003, 0.003, 0.003, 0.003]
-digi.SimTrackerHitCollectionName = ["VertexBarrelCollection"]
+try:
+    digi.SimTrackerHitCollectionName = ["VertexBarrelCollection"]
+except AttributeError:
+    digi.SimTrackHitCollectionName = ["VertexBarrelCollection"]
 digi.SimTrkHitRelCollection = ["VXDTrackerHitRelations"]
 digi.TrackerHitCollectionName = ["VXDTrackerHits"]
 

--- a/k4Reco/DDPlanarDigi/options/runDDPlanarDigi.py
+++ b/k4Reco/DDPlanarDigi/options/runDDPlanarDigi.py
@@ -38,10 +38,7 @@ digi.SubDetectorName = "Vertex"
 digi.IsStrip = False
 digi.ResolutionU = [0.003, 0.003, 0.003, 0.003, 0.003, 0.003]
 digi.ResolutionV = [0.003, 0.003, 0.003, 0.003, 0.003, 0.003]
-try:
-    digi.SimTrackerHitCollectionName = ["VertexBarrelCollection"]
-except AttributeError:
-    digi.SimTrackHitCollectionName = ["VertexBarrelCollection"]
+digi.SimTrackHitCollectionName = ["VertexBarrelCollection"]
 digi.SimTrkHitRelCollection = ["VXDTrackerHitRelations"]
 digi.TrackerHitCollectionName = ["VXDTrackerHits"]
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Rename SimTrackerHitCollectionName to SimTrackHitCollectionName in DDPlanarDigi, because this is the original input name

ENDRELEASENOTES

I'm adding this to the CLD reconstruction and it will be too messy if the names are also different. Sorry for those using it, but it was a mistake since the beginning.

As an example, this can be made compatible with the previous version by adding to the steering file a try-except block:

``` python
try:
    digi.SimTrackHitCollectionName = ["VertexBarrelCollection"]
except AttributeError:
    digi.SimTrackerHitCollectionName = ["VertexBarrelCollection"]
```

Tagging @mahmoudali2 and @samf25 who may be using DDPlanarDigi