### PR TITLE
Fix the rare cases when the number of tracks is different in Gaudi and Marlin

### DIFF
--- a/k4Reco/ConformalTracking/components/ConformalTracking.cpp
+++ b/k4Reco/ConformalTracking/components/ConformalTracking.cpp
@@ -681,12 +681,7 @@ edm4hep::TrackCollection ConformalTracking::operator()(
 
       if (track_inv.getTrackerHits().size() > track.getTrackerHits().size()) {
         debug() << " Track is replaced. " << endmsg;
-        // TODO
-        // track.swap(track_inv);
-        // marlinTrack.swap(marlinTrack_inv);
         std::swap(track, track_inv);
-        // std::swap(marlinTrk, marlinTrack_inv);
-        // marlinTrk.swap(marlinTrack_inv);
         fitError = fitError_inv;
       } else {
         debug() << " Track is not replaced. " << endmsg;

--- a/k4Reco/ConformalTracking/components/ConformalTracking.cpp
+++ b/k4Reco/ConformalTracking/components/ConformalTracking.cpp
@@ -682,8 +682,11 @@ edm4hep::TrackCollection ConformalTracking::operator()(
       if (track_inv.getTrackerHits().size() > track.getTrackerHits().size()) {
         debug() << " Track is replaced. " << endmsg;
         // TODO
-        //  track.swap(track_inv);
-        //  marlinTrack.swap(marlinTrack_inv);
+        // track.swap(track_inv);
+        // marlinTrack.swap(marlinTrack_inv);
+        std::swap(track, track_inv);
+        // std::swap(marlinTrk, marlinTrack_inv);
+        // marlinTrk.swap(marlinTrack_inv);
         fitError = fitError_inv;
       } else {
         debug() << " Track is not replaced. " << endmsg;


### PR DESCRIPTION
Observed in CI very rarely and reproducible by increasing the number of muons in
https://github.com/key4hep/k4Reco/blob/4252afc19133e10e14bc036cbde8cb9718641d40/test/CMakeLists.txt#L34 (and even then it doesn't always happen), this is a fix that will use the track obtained in the backwards direction instead of forward when certain conditions are met. It was marked as a TODO from the porting.


BEGINRELEASENOTES
- ConformalTracking: Use the track obtained in the backwards direction when it has more hits than the track in the forward direction.

ENDRELEASENOTES

I'm running the tests in a loop until this fails, and so far it looks good even when simulating events with 500 muons. Command to reproduce (from the build directory):
``` bash
while rm $PWD/test/*.root && ctest -R run_ddsim && ctest -R "run_marlin_wrapper$" && ctest -R ConformalTracking; do :; done
```

Note that the other swap that was there originally `marlinTrack.swap(marlinTrack_inv);`, is not needed since neither `marlinTrack` nor `marlinTrack_inv` are used after that line.