### PR TITLE
Use TrackerHit instead of TrackerHitPlane for Tracking

### DIFF
--- a/k4Reco/ConformalTracking/components/ConformalTracking.cpp
+++ b/k4Reco/ConformalTracking/components/ConformalTracking.cpp
@@ -70,7 +70,6 @@ inline bool sort_by_radius(const edm4hep::TrackerHit* hit1, const edm4hep::Track
          edm4hep::utils::magnitudeTransverse(hit2->getPosition());
 }
 
-
 // Sort kd hits from smaller to larger radius
 inline bool sort_by_lower_radiusKD(const SKDCluster& hit1, const SKDCluster& hit2) {
   return hit1->getR() < hit2->getR();
@@ -645,8 +644,7 @@ edm4hep::TrackCollection ConformalTracking::operator()(
     }
 
     // Sort the hits from smaller to larger radius
-    std::ranges::sort(trackHits,
-                      (bool (*)(const edm4hep::TrackerHit*, const edm4hep::TrackerHit*))sort_by_radius);
+    std::ranges::sort(trackHits, (bool (*)(const edm4hep::TrackerHit*, const edm4hep::TrackerHit*))sort_by_radius);
 
     // Now we can make the track object and relations object, and fit the track
     edm4hep::MutableTrack track;

--- a/k4Reco/ConformalTracking/components/ConformalTracking.cpp
+++ b/k4Reco/ConformalTracking/components/ConformalTracking.cpp
@@ -34,6 +34,7 @@
 #include <edm4hep/SimTrackerHit.h>
 #include <edm4hep/Track.h>
 #include <edm4hep/TrackState.h>
+#include <edm4hep/TrackerHit.h>
 #include <edm4hep/TrackerHitPlaneCollection.h>
 #include <edm4hep/Vector3d.h>
 #include <edm4hep/utils/vector_utils.h>
@@ -53,14 +54,22 @@
 #include <TStopwatch.h>
 
 #include <algorithm>
-#include <cfloat>
 #include <cmath>
 #include <functional>
 #include <iostream>
 #include <stdexcept>
 
-bool sort_by_radius(const edm4hep::TrackerHitPlane& hit1, const edm4hep::TrackerHitPlane& hit2);
-bool sort_by_radius(const edm4hep::TrackerHitPlane* hit1, const edm4hep::TrackerHitPlane* hit2);
+// Sort tracker hits from smaller to larger radius
+inline bool sort_by_radius(const edm4hep::TrackerHitPlane& hit1, const edm4hep::TrackerHitPlane& hit2) {
+  return edm4hep::utils::magnitudeTransverse(hit1.getPosition()) <
+         edm4hep::utils::magnitudeTransverse(hit2.getPosition());
+}
+
+inline bool sort_by_radius(const edm4hep::TrackerHit* hit1, const edm4hep::TrackerHit* hit2) {
+  return edm4hep::utils::magnitudeTransverse(hit1->getPosition()) <
+         edm4hep::utils::magnitudeTransverse(hit2->getPosition());
+}
+
 
 // Sort kd hits from smaller to larger radius
 inline bool sort_by_lower_radiusKD(const SKDCluster& hit1, const SKDCluster& hit2) {
@@ -626,14 +635,18 @@ edm4hep::TrackCollection ConformalTracking::operator()(
     info() << "- Fitting track " << &conformalTrack << endmsg;
 
     // Make the LCIO track hit vector
-    std::vector<const edm4hep::TrackerHitPlane*> trackHits;
+    std::vector<const edm4hep::TrackerHit*> trackHits;
+    std::vector<edm4hep::TrackerHit> trackHitsObjects;
     for (const auto& cluster : conformalTrack->m_clusters) {
-      trackHits.push_back(&kdClusterMap[cluster]);
+      trackHitsObjects.emplace_back(kdClusterMap[cluster]);
+    }
+    for (auto& trackHit : trackHitsObjects) {
+      trackHits.push_back(&trackHit);
     }
 
     // Sort the hits from smaller to larger radius
     std::ranges::sort(trackHits,
-                      (bool (*)(const edm4hep::TrackerHitPlane*, const edm4hep::TrackerHitPlane*))sort_by_radius);
+                      (bool (*)(const edm4hep::TrackerHit*, const edm4hep::TrackerHit*))sort_by_radius);
 
     // Now we can make the track object and relations object, and fit the track
     edm4hep::MutableTrack track;
@@ -907,17 +920,6 @@ StatusCode ConformalTracking::finalize() {
     file->Close();
   }
   return StatusCode::SUCCESS;
-}
-
-// Sort tracker hits from smaller to larger radius
-inline bool sort_by_radius(const edm4hep::TrackerHitPlane& hit1, const edm4hep::TrackerHitPlane& hit2) {
-  return edm4hep::utils::magnitudeTransverse(hit1.getPosition()) <
-         edm4hep::utils::magnitudeTransverse(hit2.getPosition());
-}
-
-inline bool sort_by_radius(const edm4hep::TrackerHitPlane* hit1, const edm4hep::TrackerHitPlane* hit2) {
-  return edm4hep::utils::magnitudeTransverse(hit1->getPosition()) <
-         edm4hep::utils::magnitudeTransverse(hit2->getPosition());
 }
 
 // Sort kd hits from larger to smaller radius

--- a/k4Reco/ConformalTracking/include/GaudiTrkUtils.h
+++ b/k4Reco/ConformalTracking/include/GaudiTrkUtils.h
@@ -58,32 +58,30 @@ public:
   GaudiTrkUtils(GaudiTrkUtils&&) = delete;
   GaudiTrkUtils& operator=(GaudiTrkUtils&&) = delete;
 
-  int createFinalisedLCIOTrack(GaudiDDKalTestTrack& marlinTrk,
-                               const std::vector<const edm4hep::TrackerHitPlane*>& hit_list,
+  int createFinalisedLCIOTrack(GaudiDDKalTestTrack& marlinTrk, const std::vector<const edm4hep::TrackerHit*>& hit_list,
                                edm4hep::MutableTrack& track, bool fit_direction,
                                const edm4hep::CovMatrix6f& initial_cov_for_prefit, float bfield_z,
                                double maxChi2Increment);
 
-  int createFinalisedLCIOTrack(GaudiDDKalTestTrack& marlinTrk,
-                               const std::vector<const edm4hep::TrackerHitPlane*>& hit_list,
+  int createFinalisedLCIOTrack(GaudiDDKalTestTrack& marlinTrk, const std::vector<const edm4hep::TrackerHit*>& hit_list,
                                edm4hep::MutableTrack& track, bool fit_direction, edm4hep::TrackState& pre_fit,
                                double maxChi2Increment);
 
-  int createPrefit(const std::vector<const edm4hep::TrackerHitPlane*>& hit_list, edm4hep::TrackState& pre_fit,
+  int createPrefit(const std::vector<const edm4hep::TrackerHit*>& hit_list, edm4hep::TrackState& pre_fit,
                    float bfield_z);
 
-  int createFit(const std::vector<const edm4hep::TrackerHitPlane*>& hit_list, GaudiDDKalTestTrack& marlinTrk,
+  int createFit(const std::vector<const edm4hep::TrackerHit*>& hit_list, GaudiDDKalTestTrack& marlinTrk,
                 edm4hep::TrackState& pre_fit, bool fit_direction, double maxChi2Increment);
 
   int finaliseLCIOTrack(GaudiDDKalTestTrack& marlintrk, edm4hep::MutableTrack& track,
-                        const std::vector<const edm4hep::TrackerHitPlane*>& hit_list, bool fit_direction);
+                        const std::vector<const edm4hep::TrackerHit*>& hit_list, bool fit_direction);
 
   void addHitNumbersToTrack(std::vector<int32_t>& subdetectorHitNumbers,
-                            const std::vector<const edm4hep::TrackerHitPlane*>& hit_list, bool hits_in_fit,
+                            const std::vector<const edm4hep::TrackerHit*>& hit_list, bool hits_in_fit,
                             const dd4hep::DDSegmentation::BitFieldCoder& cellID_encoder) const;
 
   int createTrackStateAtCaloFace(GaudiDDKalTestTrack& marlintrk, edm4hep::TrackState& trkStateCalo,
-                                 const edm4hep::TrackerHitPlane* trkhit, bool tanL_is_positive);
+                                 const edm4hep::TrackerHit* trkhit, bool tanL_is_positive);
 
 private:
   const Gaudi::Algorithm* m_thisAlg;

--- a/k4Reco/ConformalTracking/src/GaudiTrkUtils.cpp
+++ b/k4Reco/ConformalTracking/src/GaudiTrkUtils.cpp
@@ -23,6 +23,8 @@
 
 #include "HelixTrack.h"
 
+#include <kaltest/TKalTrack.h>
+
 #include <edm4hep/MutableTrack.h>
 #include <edm4hep/Track.h>
 #include <edm4hep/TrackState.h>
@@ -62,7 +64,7 @@ void setStreamlogOutputLevel(const Gaudi::Algorithm* thisAlg, streamlog::logscop
 }
 
 int GaudiTrkUtils::createFinalisedLCIOTrack(GaudiDDKalTestTrack& marlinTrk,
-                                            const std::vector<const edm4hep::TrackerHitPlane*>& hit_list,
+                                            const std::vector<const edm4hep::TrackerHit*>& hit_list,
                                             edm4hep::MutableTrack& track, bool fit_direction,
                                             const edm4hep::CovMatrix6f& initial_cov_for_prefit, float bfield_z,
                                             double maxChi2Increment) {
@@ -85,7 +87,7 @@ int GaudiTrkUtils::createFinalisedLCIOTrack(GaudiDDKalTestTrack& marlinTrk,
 }
 
 int GaudiTrkUtils::createFinalisedLCIOTrack(GaudiDDKalTestTrack& marlinTrk,
-                                            const std::vector<const edm4hep::TrackerHitPlane*>& hit_list,
+                                            const std::vector<const edm4hep::TrackerHit*>& hit_list,
                                             edm4hep::MutableTrack& track, bool fit_direction,
                                             edm4hep::TrackState& pre_fit, double maxChi2Increment) {
   if (hit_list.empty())
@@ -102,14 +104,14 @@ int GaudiTrkUtils::createFinalisedLCIOTrack(GaudiDDKalTestTrack& marlinTrk,
   return error;
 }
 
-int GaudiTrkUtils::createPrefit(const std::vector<const edm4hep::TrackerHitPlane*>& hit_list,
-                                edm4hep::TrackState& pre_fit, float bfield_z) {
+int GaudiTrkUtils::createPrefit(const std::vector<const edm4hep::TrackerHit*>& hit_list, edm4hep::TrackState& pre_fit,
+                                float bfield_z) {
   if (hit_list.empty())
     return 1;
 
   // loop over all the hits and create a list consisting only 2D hits
 
-  std::vector<const edm4hep::TrackerHitPlane*> twoD_hits;
+  std::vector<const edm4hep::TrackerHit*> twoD_hits;
 
   for (unsigned ihit = 0; ihit < hit_list.size(); ++ihit) {
     // check if this a space point or 2D hit
@@ -160,9 +162,8 @@ int GaudiTrkUtils::createPrefit(const std::vector<const edm4hep::TrackerHitPlane
   return 0;
 }
 
-int GaudiTrkUtils::createFit(const std::vector<const edm4hep::TrackerHitPlane*>& hit_list,
-                             GaudiDDKalTestTrack& marlinTrk, edm4hep::TrackState& pre_fit, bool fit_direction,
-                             double maxChi2Increment) {
+int GaudiTrkUtils::createFit(const std::vector<const edm4hep::TrackerHit*>& hit_list, GaudiDDKalTestTrack& marlinTrk,
+                             edm4hep::TrackState& pre_fit, bool fit_direction, double maxChi2Increment) {
   if (hit_list.empty())
     return 1;
 
@@ -175,11 +176,11 @@ int GaudiTrkUtils::createFit(const std::vector<const edm4hep::TrackerHitPlane*>&
   //  start by trying to add the hits to the track we want to finally use.
   m_thisAlg->debug() << "MarlinTrk::createFit Start Fit: AddHits: number of hits to fit " << hit_list.size() << endmsg;
 
-  std::vector<const edm4hep::TrackerHitPlane*> added_hits;
+  std::vector<const edm4hep::TrackerHit*> added_hits;
   unsigned int ndof_added = 0;
 
   for (auto it = hit_list.begin(); it != hit_list.end(); ++it) {
-    const edm4hep::TrackerHitPlane* trkHit = *it;
+    const auto* trkHit = *it;
     bool isSuccessful = false;
 
     // TODO: check if bitset works
@@ -237,7 +238,7 @@ int GaudiTrkUtils::createFit(const std::vector<const edm4hep::TrackerHitPlane*>&
 }
 
 int GaudiTrkUtils::finaliseLCIOTrack(GaudiDDKalTestTrack& marlintrk, edm4hep::MutableTrack& track,
-                                     const std::vector<const edm4hep::TrackerHitPlane*>& hit_list, bool fit_direction) {
+                                     const std::vector<const edm4hep::TrackerHit*>& hit_list, bool fit_direction) {
   int ndf = 0;
   double chi2 = -DBL_MAX;
 
@@ -259,7 +260,7 @@ int GaudiTrkUtils::finaliseLCIOTrack(GaudiDDKalTestTrack& marlintrk, edm4hep::Mu
   // add these to the track, add spacepoints as long as at least on strip hit is used.
   ////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-  std::vector<const edm4hep::TrackerHitPlane*> used_hits;
+  std::vector<const edm4hep::TrackerHit*> used_hits;
 
   const auto& hits_in_fit = marlintrk.getHitsInFit();
   const auto& outliers = marlintrk.getOutliers();
@@ -271,7 +272,7 @@ int GaudiTrkUtils::finaliseLCIOTrack(GaudiDDKalTestTrack& marlintrk, edm4hep::Mu
   ///////////////////////////////////////////////
 
   for (unsigned ihit = 0; ihit < hit_list.size(); ++ihit) {
-    const edm4hep::TrackerHitPlane* trkHit = hit_list[ihit];
+    const auto* trkHit = hit_list[ihit];
     // TODO
     // if( UTIL::BitSet32( trkHit.getType() )[ UTIL::ILDTrkHitTypeBit::COMPOSITE_SPACEPOINT ]   ){ //it is a composite
     // spacepoint
@@ -323,11 +324,9 @@ int GaudiTrkUtils::finaliseLCIOTrack(GaudiDDKalTestTrack& marlintrk, edm4hep::Mu
   ///////////////////////////////////////////////////////////////////////////
 
   edm4hep::TrackState trkStateAtFirstHit;
-  const edm4hep::TrackerHitPlane* firstHit =
-      fit_direction == false ? hits_in_fit.back().first : hits_in_fit.front().first;
-  const edm4hep::TrackerHitPlane* lastHit =
-      fit_direction == false ? hits_in_fit.front().first : hits_in_fit.back().first;
-  const edm4hep::TrackerHitPlane* last_constrained_hit = marlintrk.getTrackerHitAtPositiveNDF();
+  const edm4hep::TrackerHit* firstHit = fit_direction == false ? hits_in_fit.back().first : hits_in_fit.front().first;
+  const edm4hep::TrackerHit* lastHit = fit_direction == false ? hits_in_fit.front().first : hits_in_fit.back().first;
+  const edm4hep::TrackerHit* last_constrained_hit = marlintrk.getTrackerHitAtPositiveNDF();
 
   // m_thisAlg->debug() << "MarlinTrk::finaliseLCIOTrack: firstHit : " << toString( firstHit )
   //     		  << " lastHit:                                " << toString( lastHit )
@@ -400,7 +399,7 @@ int GaudiTrkUtils::finaliseLCIOTrack(GaudiDDKalTestTrack& marlintrk, edm4hep::Mu
     ++hI;
 
     while (hI != hits_in_fit.rend()) {
-      const edm4hep::TrackerHitPlane* h = (*hI).first;
+      const edm4hep::TrackerHit* h = (*hI).first;
 
       double deltaChi;
       double maxChi2Increment = 1e10; // ???
@@ -513,7 +512,7 @@ int GaudiTrkUtils::finaliseLCIOTrack(GaudiDDKalTestTrack& marlintrk, edm4hep::Mu
 }
 
 void GaudiTrkUtils::addHitNumbersToTrack(std::vector<int32_t>& subdetectorHitNumbers,
-                                         const std::vector<const edm4hep::TrackerHitPlane*>& hit_list, bool hits_in_fit,
+                                         const std::vector<const edm4hep::TrackerHit*>& hit_list, bool hits_in_fit,
                                          const dd4hep::DDSegmentation::BitFieldCoder& cellID_encoder) const {
   // Because in EDM4hep for vector members only hits can be added, we need the whole
   // vector before starting to assign
@@ -544,7 +543,7 @@ void GaudiTrkUtils::addHitNumbersToTrack(std::vector<int32_t>& subdetectorHitNum
 }
 
 int GaudiTrkUtils::createTrackStateAtCaloFace(GaudiDDKalTestTrack& marlintrk, edm4hep::TrackState& trkStateCalo,
-                                              const edm4hep::TrackerHitPlane* trkhit, bool tanL_is_positive) {
+                                              const edm4hep::TrackerHit* trkhit, bool tanL_is_positive) {
   int return_error = 0;
   int return_error_barrel = 0;
   int return_error_endcap = 0;

--- a/k4Reco/ConformalTracking/src/GaudiTrkUtils.cpp
+++ b/k4Reco/ConformalTracking/src/GaudiTrkUtils.cpp
@@ -23,7 +23,10 @@
 
 #include "HelixTrack.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #include <kaltest/TKalTrack.h>
+#pragma GCC diagnostic pop
 
 #include <edm4hep/MutableTrack.h>
 #include <edm4hep/Track.h>

--- a/k4Reco/GaudiTrkUtils/include/GaudiDDKalTest.h
+++ b/k4Reco/GaudiTrkUtils/include/GaudiDDKalTest.h
@@ -105,7 +105,7 @@ private:
   const DDVMeasLayer* getLastMeasLayer(const THelicalTrack& helix, const TVector3& point) const;
 
   // find the measurement layer for a given hit
-  const DDVMeasLayer* findMeasLayer(const edm4hep::TrackerHitPlane& trkhit) const;
+  const DDVMeasLayer* findMeasLayer(const edm4hep::TrackerHit& trkhit) const;
 
   const DDCylinderMeasLayer* getIPLayer() const { return m_ipLayer; }
 

--- a/k4Reco/GaudiTrkUtils/include/GaudiDDKalTestTrack.h
+++ b/k4Reco/GaudiTrkUtils/include/GaudiDDKalTestTrack.h
@@ -51,7 +51,7 @@ class GaudiDDKalTestTrack {
 public:
   GaudiDDKalTestTrack(
       const Gaudi::Algorithm* thisAlg, GaudiDDKalTest* ktest,
-      std::shared_ptr<std::map<const edm4hep::TrackerHitPlane*, DDVTrackHit*>> edm4hep_hits_to_kaltest_hits = nullptr);
+      std::shared_ptr<std::map<const edm4hep::TrackerHit*, DDVTrackHit*>> edm4hep_hits_to_kaltest_hits = nullptr);
 
 public:
   GaudiDDKalTestTrack(const GaudiDDKalTestTrack&) = delete;
@@ -63,17 +63,17 @@ public:
   /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
    *  this order will define the direction of the energy loss used in the fit
    */
-  int addHit(const edm4hep::TrackerHitPlane* hit);
+  int addHit(const edm4hep::TrackerHit* hit);
 
   /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
    *  this order will define the direction of the energy loss used in the fit
    */
-  int addHit(const edm4hep::TrackerHitPlane* trkhit, const DDVMeasLayer* ml);
+  int addHit(const edm4hep::TrackerHit* trkhit, const DDVMeasLayer* ml);
 
   /** add hit to track - the hits have to be added ordered in time ( i.e. typically outgoing )
    *  this order will define the direction of the energy loss used in the fit
    */
-  int addHit(const edm4hep::TrackerHitPlane* trkhit, DDVTrackHit* kalhit, const DDVMeasLayer* ml);
+  int addHit(const edm4hep::TrackerHit* trkhit, DDVTrackHit* kalhit, const DDVMeasLayer* ml);
 
   /** initialise the fit with a track state
    *  the fit direction has to be specified using IMarlinTrack::backward or IMarlinTrack::forward.
@@ -93,12 +93,12 @@ public:
 
   /** smooth track states from the last filtered hit back to the measurement site associated with the given hit
    */
-  int smooth(const edm4hep::TrackerHitPlane* hit);
+  int smooth(const edm4hep::TrackerHit* hit);
 
   /** update the current fit using the supplied hit, return code via int. Provides the Chi2 increment to the fit from
    * adding the hit via reference. the given hit will not be added if chi2increment > maxChi2Increment.
    */
-  int addAndFit(const edm4hep::TrackerHitPlane* hit, double& chi2increment, double maxChi2Increment = DBL_MAX);
+  int addAndFit(const edm4hep::TrackerHit* hit, double& chi2increment, double maxChi2Increment = DBL_MAX);
 
   /** update the current fit using the supplied hit, return code via int. Provides the Chi2 increment to the fit from
    * adding the hit via reference. the given hit will not be added if chi2increment > maxChi2Increment.
@@ -107,21 +107,21 @@ public:
 
   /** get track state at measurement associated with the given hit, returning TrackState, chi2 and ndf via reference
    */
-  int getTrackState(const edm4hep::TrackerHitPlane* hit, edm4hep::TrackState& ts, double& chi2, int& ndf) const;
+  int getTrackState(const edm4hep::TrackerHit* hit, edm4hep::TrackState& ts, double& chi2, int& ndf) const;
 
   /** get the list of hits included in the fit, together with the chi2 contributions of the hits.
    *  Pointers to the hits together with their chi2 contribution will be filled into a vector of
    *  pairs consitining of the pointer as the first part of the pair and the chi2 contribution as
    *  the second.
    */
-  const std::vector<std::pair<const edm4hep::TrackerHitPlane*, double>>& getHitsInFit() const;
+  const std::vector<std::pair<const edm4hep::TrackerHit*, double>>& getHitsInFit() const;
 
   /** get the list of hits which have been rejected by from the fit due to the a chi2 increment greater than threshold,
    *  Pointers to the hits together with their chi2 contribution will be filled into a vector of
    *  pairs consitining of the pointer as the first part of the pair and the chi2 contribution as
    *  the second.
    */
-  const std::vector<std::pair<const edm4hep::TrackerHitPlane*, double>>& getOutliers() const;
+  const std::vector<std::pair<const edm4hep::TrackerHit*, double>>& getOutliers() const;
 
   /** get the current number of degrees of freedom for the fit.
    */
@@ -129,12 +129,12 @@ public:
 
   /** get TrackeHit at which fit became constrained, i.e. ndf >= 0
    */
-  const edm4hep::TrackerHitPlane* getTrackerHitAtPositiveNDF() const;
+  const edm4hep::TrackerHit* getTrackerHitAtPositiveNDF() const;
 
   /** propagate the fit at the measurement site associated with the given hit, to the point of closest approach to the
    * given point, returning TrackState, chi2 and ndf via reference
    */
-  int propagate(const edm4hep::Vector3d& point, const edm4hep::TrackerHitPlane* hit, edm4hep::TrackState& ts,
+  int propagate(const edm4hep::Vector3d& point, const edm4hep::TrackerHit* hit, edm4hep::TrackState& ts,
                 double& chi2, int& ndf);
 
   /** propagate the fit at the provided measurement site, to the point of closest approach to the given point,
@@ -146,7 +146,7 @@ public:
   /** propagate the fit at the measurement site associated with the given hit, to numbered sensitive layer,
    *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference
    */
-  int propagateToLayer(int layerID, const edm4hep::TrackerHitPlane* hit, edm4hep::TrackState& ts, double& chi2,
+  int propagateToLayer(int layerID, const edm4hep::TrackerHit* hit, edm4hep::TrackState& ts, double& chi2,
                        int& ndf, int& detElementID, int mode = modeClosest);
 
   /** propagate the fit at the measurement site, to numbered sensitive layer,
@@ -187,7 +187,7 @@ public:
 
   /** get the measurement site associated with the given lcio TrackerHit trkhit
    */
-  int getSiteFromLCIOHit(const edm4hep::TrackerHitPlane* trkhit, TKalTrackSite*& site) const;
+  int getSiteFromLCIOHit(const edm4hep::TrackerHit* trkhit, TKalTrackSite*& site) const;
 
   /** helper function to restrict the range of the azimuthal angle to ]-pi,pi]*/
   inline double toBaseRange(double phi) const {
@@ -199,7 +199,7 @@ public:
     return phi;
   }
 
-  std::unique_ptr<TKalTrack> m_kaltrack{}; // unique ptr to be able to forward declare
+  std::unique_ptr<TKalTrack> m_kaltrack{}; //unique ptr to be able to forward declare
   TObjArray* m_kalhits = nullptr;
   GaudiDDKalTest* m_ktest = nullptr;
   // used to store whether initial track state has been supplied or created
@@ -208,24 +208,24 @@ public:
   bool m_fitDirection = false;
   // used to store whether smoothing has been performed
   bool m_smoothed = false;
-  const edm4hep::TrackerHitPlane* m_trackHitAtPositiveNDF = nullptr;
+  const edm4hep::TrackerHit* m_trackHitAtPositiveNDF = nullptr;
   int m_hitIndexAtPositiveNDF = -1;
 
   // map to store relation between lcio hits and measurement sites
-  std::map<const edm4hep::TrackerHitPlane*, TKalTrackSite*> m_hit_used_for_sites{};
+  std::map<const edm4hep::TrackerHit*, TKalTrackSite*> m_hit_used_for_sites{};
 
   // map to store relation between lcio hits kaltest hits
-  std::map<DDVTrackHit*, const edm4hep::TrackerHitPlane*> m_kaltest_hits_to_edm4hep_hits{};
-  std::shared_ptr<std::map<const edm4hep::TrackerHitPlane*, DDVTrackHit*>> m_edm4hep_hits_to_kaltest_hits{};
+  std::map<DDVTrackHit*, const edm4hep::TrackerHit*> m_kaltest_hits_to_edm4hep_hits{};
+  std::shared_ptr<std::map<const edm4hep::TrackerHit*, DDVTrackHit*>> m_edm4hep_hits_to_kaltest_hits{};
 
   // vector to store lcio hits rejected for measurement sites
-  std::vector<const edm4hep::TrackerHitPlane*> m_hit_not_used_for_sites{};
+  std::vector<const edm4hep::TrackerHit*> m_hit_not_used_for_sites{};
 
   // vector to store the chi-sqaure increment for measurement sites
-  std::vector<std::pair<const edm4hep::TrackerHitPlane*, double>> m_hit_chi2_values{};
+  std::vector<std::pair<const edm4hep::TrackerHit*, double>> m_hit_chi2_values{};
 
   // vector to store the chi-sqaure increment for measurement sites
-  std::vector<std::pair<const edm4hep::TrackerHitPlane*, double>> m_outlier_chi2_values{};
+  std::vector<std::pair<const edm4hep::TrackerHit*, double>> m_outlier_chi2_values{};
 
   // Originally not present in MarlinDDKalTest, this is needed to be able to use
   // logging from Gaudi

--- a/k4Reco/GaudiTrkUtils/include/GaudiDDKalTestTrack.h
+++ b/k4Reco/GaudiTrkUtils/include/GaudiDDKalTestTrack.h
@@ -134,8 +134,8 @@ public:
   /** propagate the fit at the measurement site associated with the given hit, to the point of closest approach to the
    * given point, returning TrackState, chi2 and ndf via reference
    */
-  int propagate(const edm4hep::Vector3d& point, const edm4hep::TrackerHit* hit, edm4hep::TrackState& ts,
-                double& chi2, int& ndf);
+  int propagate(const edm4hep::Vector3d& point, const edm4hep::TrackerHit* hit, edm4hep::TrackState& ts, double& chi2,
+                int& ndf);
 
   /** propagate the fit at the provided measurement site, to the point of closest approach to the given point,
    *  returning TrackState, chi2 and ndf via reference
@@ -146,8 +146,8 @@ public:
   /** propagate the fit at the measurement site associated with the given hit, to numbered sensitive layer,
    *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference
    */
-  int propagateToLayer(int layerID, const edm4hep::TrackerHit* hit, edm4hep::TrackState& ts, double& chi2,
-                       int& ndf, int& detElementID, int mode = modeClosest);
+  int propagateToLayer(int layerID, const edm4hep::TrackerHit* hit, edm4hep::TrackState& ts, double& chi2, int& ndf,
+                       int& detElementID, int mode = modeClosest);
 
   /** propagate the fit at the measurement site, to numbered sensitive layer,
    *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference
@@ -199,7 +199,7 @@ public:
     return phi;
   }
 
-  std::unique_ptr<TKalTrack> m_kaltrack{}; //unique ptr to be able to forward declare
+  std::unique_ptr<TKalTrack> m_kaltrack{}; // unique ptr to be able to forward declare
   TObjArray* m_kalhits = nullptr;
   GaudiDDKalTest* m_ktest = nullptr;
   // used to store whether initial track state has been supplied or created

--- a/k4Reco/GaudiTrkUtils/src/GaudiDDKalTest.cpp
+++ b/k4Reco/GaudiTrkUtils/src/GaudiDDKalTest.cpp
@@ -32,7 +32,7 @@
 #include <DDKalTest/DDKalDetector.h>
 #include <DDKalTest/DDVMeasLayer.h>
 
-#include <edm4hep/TrackerHitPlane.h>
+#include <edm4hep/TrackerHit.h>
 
 #include <Gaudi/Algorithm.h>
 
@@ -311,7 +311,7 @@ const DDVMeasLayer* GaudiDDKalTest::getLastMeasLayer(const THelicalTrack& hel, T
   return dynamic_cast<const DDVMeasLayer*>(ml_retval);
 }
 
-const DDVMeasLayer* GaudiDDKalTest::findMeasLayer(const edm4hep::TrackerHitPlane& trkhit) const {
+const DDVMeasLayer* GaudiDDKalTest::findMeasLayer(const edm4hep::TrackerHit& trkhit) const {
   const TVector3 hit_pos(trkhit.getPosition()[0], trkhit.getPosition()[1], trkhit.getPosition()[2]);
 
   return this->findMeasLayer(trkhit.getCellID(), hit_pos);

--- a/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
+++ b/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
@@ -24,7 +24,6 @@
 #include <kaltest/TKalFilterCond.h>
 #include <kaltest/TKalTrack.h>
 #include <kaltest/TKalTrackSite.h>
-#include <kaltest/TKalDetCradle.h>
 
 // Remove when the warnings are fixed in DDKalTest
 #pragma GCC diagnostic push

--- a/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
+++ b/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
@@ -24,6 +24,7 @@
 #include <kaltest/TKalFilterCond.h>
 #include <kaltest/TKalTrack.h>
 #include <kaltest/TKalTrackSite.h>
+#include <kaltest/TKalDetCradle.h>
 
 // Remove when the warnings are fixed in DDKalTest
 #pragma GCC diagnostic push
@@ -75,7 +76,7 @@ protected:
 // //---------------------------------------------------------------------------------------------------------------
 GaudiDDKalTestTrack::GaudiDDKalTestTrack(
     const Gaudi::Algorithm* algorithm, GaudiDDKalTest* ktest,
-    std::shared_ptr<std::map<const edm4hep::TrackerHitPlane*, DDVTrackHit*>> edm4hep_hits_to_kaltest_hits)
+    std::shared_ptr<std::map<const edm4hep::TrackerHit*, DDVTrackHit*>> edm4hep_hits_to_kaltest_hits)
     : m_ktest(ktest), m_edm4hep_hits_to_kaltest_hits(edm4hep_hits_to_kaltest_hits), m_thisAlg(algorithm) {
   m_kaltrack.reset(new TKalTrack());
   m_kaltrack->SetOwner();
@@ -91,28 +92,32 @@ GaudiDDKalTestTrack::GaudiDDKalTestTrack(
   m_hitIndexAtPositiveNDF = 0;
 
   if (!m_edm4hep_hits_to_kaltest_hits) {
-    m_edm4hep_hits_to_kaltest_hits = std::make_shared<std::map<const edm4hep::TrackerHitPlane*, DDVTrackHit*>>();
+    m_edm4hep_hits_to_kaltest_hits = std::make_shared<std::map<const edm4hep::TrackerHit*, DDVTrackHit*>>();
   }
 }
 
 GaudiDDKalTestTrack::~GaudiDDKalTestTrack() = default;
 
-int GaudiDDKalTestTrack::addHit(const edm4hep::TrackerHitPlane* trkhit) {
+int GaudiDDKalTestTrack::addHit(const edm4hep::TrackerHit* trkhit) {
   return this->addHit(trkhit, m_ktest->findMeasLayer(*trkhit));
 }
 
-int GaudiDDKalTestTrack::addHit(const edm4hep::TrackerHitPlane* trkhit, const DDVMeasLayer* ml) {
+int GaudiDDKalTestTrack::addHit(const edm4hep::TrackerHit* trkhit, const DDVMeasLayer* ml) {
   m_thisAlg->debug() << "GaudiDDKalTestTrack::addHit: trkhit = " << trkhit->id() << " addr: " << trkhit
                      << " ml = " << ml << endmsg;
 
   if (trkhit && ml) {
     // TODO: a LCIO hit has to be created because it's needed downstream
+    if (!trkhit->isA<edm4hep::TrackerHitPlane>()) {
+      throw std::runtime_error(
+          "GaudiDDKalTestTrack::addHit - trkhit is not a TrackerHitPlane, this is not implemented yet");
+    }
     auto hit = IMPL::TrackerHitPlaneImpl();
     double pos[3] = {trkhit->getPosition()[0], trkhit->getPosition()[1], trkhit->getPosition()[2]};
     hit.setPosition(pos);
     hit.setCellID0(trkhit->getCellID());
-    hit.setdU(trkhit->getDu());
-    hit.setdV(trkhit->getDv());
+    hit.setdU(trkhit->as<edm4hep::TrackerHitPlane>().getDu());
+    hit.setdV(trkhit->as<edm4hep::TrackerHitPlane>().getDv());
 
     // Not needed
     // hit.setCovMatrix(lcioCov);
@@ -135,7 +140,7 @@ int GaudiDDKalTestTrack::addHit(const edm4hep::TrackerHitPlane* trkhit, const DD
   }
 }
 
-int GaudiDDKalTestTrack::addHit(const edm4hep::TrackerHitPlane* trkhit, DDVTrackHit* kalhit, const DDVMeasLayer* ml) {
+int GaudiDDKalTestTrack::addHit(const edm4hep::TrackerHit* trkhit, DDVTrackHit* kalhit, const DDVMeasLayer* ml) {
   if (kalhit && ml) {
     m_kalhits->Add(kalhit);                             // Add hit and set surface found
     m_kaltest_hits_to_edm4hep_hits[kalhit] = trkhit;    // add hit to map relating lcio and kaltest hits
@@ -408,8 +413,7 @@ int GaudiDDKalTestTrack::addAndFit(DDVTrackHit* kalhit, double& chi2increment, T
   return 0;
 }
 
-int GaudiDDKalTestTrack::addAndFit(const edm4hep::TrackerHitPlane* trkhit, double& chi2increment,
-                                   double maxChi2Increment) {
+int GaudiDDKalTestTrack::addAndFit(const edm4hep::TrackerHit* trkhit, double& chi2increment, double maxChi2Increment) {
   if (!trkhit) {
     m_thisAlg->debug() << "GaudiDDKalTestTrack::addAndFit( EVENT::TrackerHit* trkhit, double& chi2increment, "
                           "double maxChi2Increment): trkhit == 0"
@@ -500,7 +504,7 @@ int GaudiDDKalTestTrack::fit(double maxChi2Increment) {
     TKalTrackSite* site = nullptr;
     int error_code = this->addAndFit(kalhit, chi2increment, site, maxChi2Increment);
 
-    const edm4hep::TrackerHitPlane* trkhit = m_kaltest_hits_to_edm4hep_hits[kalhit];
+    const edm4hep::TrackerHit* trkhit = m_kaltest_hits_to_edm4hep_hits[kalhit];
 
     if (error_code == 0) { // add trkhit to map associating trkhits and sites
       m_hit_used_for_sites[trkhit] = site;
@@ -550,7 +554,7 @@ int GaudiDDKalTestTrack::fit(double maxChi2Increment) {
 
 /** smooth track states from the last filtered hit back to the measurement site associated with the given hit
  */
-int GaudiDDKalTestTrack::smooth(const edm4hep::TrackerHitPlane* trkhit) {
+int GaudiDDKalTestTrack::smooth(const edm4hep::TrackerHit* trkhit) {
   m_thisAlg->debug() << "GaudiDDKalTestTrack::smooth( EVENT::TrackerHit* " << trkhit << "  ) " << endmsg;
 
   if (!trkhit) {
@@ -574,7 +578,7 @@ int GaudiDDKalTestTrack::smooth(const edm4hep::TrackerHitPlane* trkhit) {
   return 0;
 }
 
-int GaudiDDKalTestTrack::getTrackState(const edm4hep::TrackerHitPlane* trkhit, edm4hep::TrackState& ts, double& chi2,
+int GaudiDDKalTestTrack::getTrackState(const edm4hep::TrackerHit* trkhit, edm4hep::TrackState& ts, double& chi2,
                                        int& ndf) const {
   m_thisAlg->debug()
       << "GaudiDDKalTestTrack::getTrackState( EVENT::TrackerHit* trkhit, IMPL::TrackStateImpl& ts ) using hit: "
@@ -593,7 +597,7 @@ int GaudiDDKalTestTrack::getTrackState(const edm4hep::TrackerHitPlane* trkhit, e
   return 0;
 }
 
-const std::vector<std::pair<const edm4hep::TrackerHitPlane*, double>>& GaudiDDKalTestTrack::getHitsInFit() const {
+const std::vector<std::pair<const edm4hep::TrackerHit*, double>>& GaudiDDKalTestTrack::getHitsInFit() const {
   return m_hit_chi2_values;
 
   // this needs more thought. What about when the hits are added using addAndFit?
@@ -609,7 +613,7 @@ const std::vector<std::pair<const edm4hep::TrackerHitPlane*, double>>& GaudiDDKa
   //    }
 }
 
-const std::vector<std::pair<const edm4hep::TrackerHitPlane*, double>>& GaudiDDKalTestTrack::getOutliers() const {
+const std::vector<std::pair<const edm4hep::TrackerHit*, double>>& GaudiDDKalTestTrack::getOutliers() const {
   return m_outlier_chi2_values;
   // this needs more thought. What about when the hits are added using addAndFit?
   //    // need to check the order so that we can return the list ordered in time
@@ -631,11 +635,9 @@ int GaudiDDKalTestTrack::getNDF() const {
   return const_cast<TKalTrack&>(*m_kaltrack).GetNDF();
 }
 
-const edm4hep::TrackerHitPlane* GaudiDDKalTestTrack::getTrackerHitAtPositiveNDF() const {
-  return m_trackHitAtPositiveNDF;
-}
+const edm4hep::TrackerHit* GaudiDDKalTestTrack::getTrackerHitAtPositiveNDF() const { return m_trackHitAtPositiveNDF; }
 
-int GaudiDDKalTestTrack::propagate(const edm4hep::Vector3d& point, const edm4hep::TrackerHitPlane* trkhit,
+int GaudiDDKalTestTrack::propagate(const edm4hep::Vector3d& point, const edm4hep::TrackerHit* trkhit,
                                    edm4hep::TrackState& ts, double& chi2, int& ndf) {
   TKalTrackSite* site = nullptr;
   int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -727,7 +729,7 @@ int GaudiDDKalTestTrack::propagate(const edm4hep::Vector3d& point, const TKalTra
   return 0;
 }
 
-int GaudiDDKalTestTrack::propagateToLayer(int layerID, const edm4hep::TrackerHitPlane* trkhit, edm4hep::TrackState& ts,
+int GaudiDDKalTestTrack::propagateToLayer(int layerID, const edm4hep::TrackerHit* trkhit, edm4hep::TrackState& ts,
                                           double& chi2, int& ndf, int& detElementID, int mode) {
   TKalTrackSite* site = nullptr;
   int error_code = getSiteFromLCIOHit(trkhit, site);
@@ -919,7 +921,7 @@ void GaudiDDKalTestTrack::ToLCIOTrackState(const TKalTrackSite& site, edm4hep::T
   this->ToLCIOTrackState(trkState.GetHelix(), c0, ts, chi2, ndf);
 }
 
-int GaudiDDKalTestTrack::getSiteFromLCIOHit(const edm4hep::TrackerHitPlane* trkhit, TKalTrackSite*& site) const {
+int GaudiDDKalTestTrack::getSiteFromLCIOHit(const edm4hep::TrackerHit* trkhit, TKalTrackSite*& site) const {
   const auto it = m_hit_used_for_sites.find(trkhit);
 
   if (it == m_hit_used_for_sites.end()) { // hit not associated with any site

--- a/k4Reco/Tracking/include/TruthTrackFinder.h
+++ b/k4Reco/Tracking/include/TruthTrackFinder.h
@@ -52,8 +52,7 @@ struct TruthTrackFinder final
              const std::vector<const edm4hep::MCParticleCollection*>& particleCollections) const override;
 
   template <typename T>
-  std::vector<const T*>
-  removeHitsSameLayer(const std::vector<const T*>& trackHits) const;
+  std::vector<const T*> removeHitsSameLayer(const std::vector<const T*>& trackHits) const;
 
   // Track fit parameters
   float m_initialTrackError_d0{1.e6};

--- a/k4Reco/Tracking/include/TruthTrackFinder.h
+++ b/k4Reco/Tracking/include/TruthTrackFinder.h
@@ -51,8 +51,9 @@ struct TruthTrackFinder final
              const std::vector<const edm4hep::TrackerHitSimTrackerHitLinkCollection*>& relations,
              const std::vector<const edm4hep::MCParticleCollection*>& particleCollections) const override;
 
-  std::vector<const edm4hep::TrackerHitPlane*>
-  removeHitsSameLayer(const std::vector<const edm4hep::TrackerHitPlane*>& trackHits) const;
+  template <typename T>
+  std::vector<const T*>
+  removeHitsSameLayer(const std::vector<const T*>& trackHits) const;
 
   // Track fit parameters
   float m_initialTrackError_d0{1.e6};

--- a/k4Reco/Tracking/src/ClonesAndSplitTracksFinder.cpp
+++ b/k4Reco/Tracking/src/ClonesAndSplitTracksFinder.cpp
@@ -82,9 +82,7 @@ edm4hep::TrackCollection ClonesAndSplitTracksFinder::operator()(const edm4hep::T
   const size_t nTracks = input_track_col.size();
   debug() << " >> ClonesAndSplitTracksFinder starts with " << nTracks << " tracks." << endmsg;
 
-  // establish the track collection that will be created
   auto trackVec = edm4hep::TrackCollection();
-  // _encoder->reset();
 
   //------------
   // FIRST STEP: REMOVE CLONES

--- a/k4Reco/Tracking/src/RefitFinal.cpp
+++ b/k4Reco/Tracking/src/RefitFinal.cpp
@@ -110,13 +110,10 @@ RefitFinal::operator()(const edm4hep::TrackCollection& input_track_col,
   for (size_t iTrack = 0; iTrack < nTracks; ++iTrack) {
     const auto& track = input_track_col.at(iTrack);
     const auto& trkHits = track.getTrackerHits();
-    std::vector<edm4hep::TrackerHitPlane> hits;
     // TODO: Don't create a copy because finaliseLCIOTrack and marlin_trk need pointers
+    std::vector<const edm4hep::TrackerHit*> trkHitsPtr;
+    trkHitsPtr.reserve(trkHits.size());
     for (const auto& hit : trkHits) {
-      hits.push_back(hit.as<edm4hep::TrackerHitPlane>());
-    }
-    std::vector<const edm4hep::TrackerHitPlane*> trkHitsPtr;
-    for (const auto& hit : hits) {
       trkHitsPtr.push_back(&hit);
     }
 
@@ -176,9 +173,10 @@ RefitFinal::operator()(const edm4hep::TrackCollection& input_track_col,
 
     const auto outliers = marlin_trk.getOutliers();
 
-    std::vector<const edm4hep::TrackerHitPlane*> all_hits;
-    std::vector<const edm4hep::TrackerHitPlane*> hits_in_fit_ptr;
+    std::vector<const edm4hep::TrackerHit*> all_hits;
+    std::vector<const edm4hep::TrackerHit*> hits_in_fit_ptr;
     all_hits.reserve(hits_in_fit.size() + outliers.size());
+    hits_in_fit_ptr.reserve(hits_in_fit.size());
 
     for (unsigned ihit = 0; ihit < hits_in_fit.size(); ++ihit) {
       all_hits.push_back(hits_in_fit[ihit].first);

--- a/k4Reco/Tracking/src/TruthTrackFinder.cpp
+++ b/k4Reco/Tracking/src/TruthTrackFinder.cpp
@@ -54,8 +54,7 @@ inline bool sort_by_z(const edm4hep::TrackerHit* hit1, const edm4hep::TrackerHit
 }
 
 template <typename T>
-std::vector<const T*>
-TruthTrackFinder::removeHitsSameLayer(const std::vector<const T*>& trackHits) const {
+std::vector<const T*> TruthTrackFinder::removeHitsSameLayer(const std::vector<const T*>& trackHits) const {
   std::vector<const T*> trackFilteredHits;
 
   trackFilteredHits.push_back(*(trackHits.begin()));

--- a/k4Reco/Tracking/src/TruthTrackFinder.cpp
+++ b/k4Reco/Tracking/src/TruthTrackFinder.cpp
@@ -33,8 +33,6 @@
 #include <DD4hep/Detector.h>
 
 #include <algorithm>
-#include <cfloat>
-#include <climits>
 #include <cmath>
 
 /*
@@ -44,20 +42,21 @@
 
 */
 
-inline bool sort_by_radius(const edm4hep::TrackerHitPlane* hit1, const edm4hep::TrackerHitPlane* hit2) {
+inline bool sort_by_radius(const edm4hep::TrackerHit* hit1, const edm4hep::TrackerHit* hit2) {
   return edm4hep::utils::magnitudeTransverse(hit1->getPosition()) <
          edm4hep::utils::magnitudeTransverse(hit2->getPosition());
 }
 
-inline bool sort_by_z(const edm4hep::TrackerHitPlane* hit1, const edm4hep::TrackerHitPlane* hit2) {
+inline bool sort_by_z(const edm4hep::TrackerHit* hit1, const edm4hep::TrackerHit* hit2) {
   const double z1 = fabs(hit1->getPosition()[2]);
   const double z2 = fabs(hit2->getPosition()[2]);
   return z1 < z2;
 }
 
-std::vector<const edm4hep::TrackerHitPlane*>
-TruthTrackFinder::removeHitsSameLayer(const std::vector<const edm4hep::TrackerHitPlane*>& trackHits) const {
-  std::vector<const edm4hep::TrackerHitPlane*> trackFilteredHits;
+template <typename T>
+std::vector<const T*>
+TruthTrackFinder::removeHitsSameLayer(const std::vector<const T*>& trackHits) const {
+  std::vector<const T*> trackFilteredHits;
 
   trackFilteredHits.push_back(*(trackHits.begin()));
 
@@ -146,8 +145,8 @@ MC particle at the end and get all of the hits, before making a track.
 */
 
   // Make the container
-  std::map<size_t, std::vector<const edm4hep::TrackerHitPlane*>> particleHits;
-  std::vector<edm4hep::TrackerHitPlane> hits;
+  std::map<size_t, std::vector<const edm4hep::TrackerHit*>> particleHits;
+  std::vector<edm4hep::TrackerHit> hits;
   hits.reserve(std::accumulate(trackerHitCollections.begin(), trackerHitCollections.end(), 0u,
                                [](size_t sum, const auto& collection) { return sum + collection->size(); }));
 
@@ -179,7 +178,7 @@ MC particle at the end and get all of the hits, before making a track.
       edm4hep::MCParticle particle = simHit.getParticle();
 
       // Push back the element into the container
-      hits.push_back(hit.as<edm4hep::TrackerHitPlane>());
+      hits.push_back(hit);
       particleHits[static_cast<size_t>(particle.id().index)].push_back(&hits.back());
     }
   }
@@ -203,8 +202,8 @@ MC particle at the end and get all of the hits, before making a track.
     std::sort(trackHits.begin(), trackHits.end(), sort_by_radius);
 
     // Remove the hits on the same layers (removing those with higher R)
-    auto trackFilteredByRHits = removeHitsSameLayer(trackHits);
-    if (trackFilteredByRHits.size() < 3)
+    auto trackfitHitsPtrs = removeHitsSameLayer(trackHits);
+    if (trackfitHitsPtrs.size() < 3)
       continue;
 
     /*
@@ -220,11 +219,9 @@ MC particle at the end and get all of the hits, before making a track.
     auto marlinTrack = GaudiDDKalTestTrack(this, const_cast<GaudiDDKalTest*>(&m_ddkaltest));
     auto marlinTrackZSort = GaudiDDKalTestTrack(this, const_cast<GaudiDDKalTest*>(&m_ddkaltest));
 
+    // Original comment about having to save trackfitHitsPtrs
     // Save a vector of the hits to be used (why is this not attached to the track directly?? MarlinTrkUtils to be
     // updated?)
-    std::vector<const edm4hep::TrackerHitPlane*> trackfitHits;
-    for (unsigned int itTrackHit = 0; itTrackHit < trackFilteredByRHits.size(); itTrackHit++)
-      trackfitHits.push_back(trackFilteredByRHits[itTrackHit]);
 
     // Make an initial covariance matrix with very broad default values
     edm4hep::CovMatrix6f covMatrix{};
@@ -254,33 +251,33 @@ MC particle at the end and get all of the hits, before making a track.
       //   double trueTanLambda = helix.getTanLambda();
 
       //   // float ref_point[3] = { 0., 0., 0. };
-      //   helix.moveRefPoint(trackfitHits.at(0)->getPosition()[0], trackfitHits.at(0)->getPosition()[1],
-      //                      trackfitHits.at(0)->getPosition()[2]);
+      //   helix.moveRefPoint(trackfitHitsPtrs.at(0)->getPosition()[0], trackfitHitsPtrs.at(0)->getPosition()[1],
+      //                      trackfitHitsPtrs.at(0)->getPosition()[2]);
       //   float ref_point[3] = {float(helix.getRefPointX()), float(helix.getRefPointY()), float(helix.getRefPointZ())};
       //   TrackStateImpl* trkState =
       //       new TrackStateImpl(TrackState::AtIP, trueD0, truePhi, trueOmega, trueZ0, trueTanLambda, covMatrix,
       //       ref_point);
 
-      //   // int prefitError =  createFit(trackfitHits, marlinTrack, trkState, m_magneticField,  direction,
+      //   // int prefitError =  createFit(trackfitHitsPtrs, marlinTrack, trkState, m_magneticField,  direction,
       //   // m_maxChi2perHit); streamlog_out(DEBUG2) << "---- createFit - error_fit = " << error_fit << endmsg;
 
       //   // if (prefitError == 0) {
-      //   //   fitError = finaliseLCIOTrack(marlinTrack, track, trackfitHits,  direction );
+      //   //   fitError = finaliseLCIOTrack(marlinTrack, track, trackfitHitsPtrs,  direction );
       //   //   streamlog_out(DEBUG2) << "---- finalisedLCIOTrack - error = " << error << endmsg;
       //   // }
 
-      //   fitError = MarlinTrk::createFinalisedLCIOTrack(marlinTrack, trackfitHits, track, direction, trkState,
+      //   fitError = MarlinTrk::createFinalisedLCIOTrack(marlinTrack, trackfitHitsPtrs, track, direction, trkState,
       //                                                  m_magneticField, m_maxChi2perHit);
 
       //   // If first fit attempt fails, try a new fit with hits ordered by z
 
       //   if (fitError != 0) {
       //     // Sort the hits from smaller to larger z
-      //     std::sort(trackfitHits.begin(), trackfitHits.end(), sort_by_z);
+      //     std::sort(trackfitHitsPtrs.begin(), trackfitHitsPtrs.end(), sort_by_z);
 
       //     // Removing the hits on the same layers (remove those with higher z)
       //     EVENT::TrackerHitVec trackFilteredByZHits;
-      //     removeHitsSameLayer(trackfitHits, trackFilteredByZHits);
+      //     removeHitsSameLayer(trackfitHitsPtrs, trackFilteredByZHits);
       //     if (trackFilteredByZHits.size() < 3)
       //       continue;
 
@@ -299,7 +296,7 @@ MC particle at the end and get all of the hits, before making a track.
 
     else {
       // DEFAULT procedure: Try to fit
-      fitError = trkUtils.createFinalisedLCIOTrack(marlinTrack, trackfitHits, track, direction, covMatrix,
+      fitError = trkUtils.createFinalisedLCIOTrack(marlinTrack, trackfitHitsPtrs, track, direction, covMatrix,
                                                    m_magneticField, m_maxChi2perHit);
 
       // If first fit attempt fails, try a new fit with hits ordered by z
@@ -309,10 +306,10 @@ MC particle at the end and get all of the hits, before making a track.
         track = edm4hep::MutableTrack();
 
         // Sort the hits from smaller to larger z
-        std::sort(trackfitHits.begin(), trackfitHits.end(), sort_by_z);
+        std::sort(trackfitHitsPtrs.begin(), trackfitHitsPtrs.end(), sort_by_z);
 
         // Removing the hits on the same layers (remove those with higher z)
-        const auto trackFilteredByZHits = removeHitsSameLayer(trackfitHits);
+        const auto trackFilteredByZHits = removeHitsSameLayer(trackfitHitsPtrs);
         if (trackFilteredByZHits.size() < 3)
           continue;
 
@@ -334,7 +331,7 @@ MC particle at the end and get all of the hits, before making a track.
     }
 
     const auto hits_in_fit = marlinTrack.getHitsInFit();
-    std::vector<const edm4hep::TrackerHitPlane*> hits_in_fit_ptr;
+    std::vector<const edm4hep::TrackerHit*> hits_in_fit_ptr;
 
     for (const auto& hit : hits_in_fit) {
       hits_in_fit_ptr.push_back(hit.first);
@@ -349,7 +346,7 @@ MC particle at the end and get all of the hits, before making a track.
     }
 
     debug() << "TruthTrackFinder: trackHits.size(): " << trackHits.size()
-            << " trackfitHits.size(): " << trackfitHits.size() << " hits_in_fit.size(): " << hits_in_fit.size()
+            << " trackfitHitsPtrs.size(): " << trackfitHitsPtrs.size() << " hits_in_fit.size(): " << hits_in_fit.size()
             << endmsg;
 
     // Push back to the output container


### PR DESCRIPTION
Several ported functions from MarlinTrkUtils use `edm4hep::TrackerHitPlane` because at the time it was just easier to use `TrackerHitPlane` everywhere. When working on Pandora and using the ported library, it is weird not to be able to use the `edm4hep::TrackerHit`s that one gets from a `edm4hep::Track`.


BEGINRELEASENOTES
- Use `edm4hep::TrackerHit` as arguments in functions belonging to the `GaudiTrkUtils` library, instead of `edm4hep::TrackerHitPlane`.

ENDRELEASENOTES