### PR TITLE
Add an overload for Pandora for the member function propagateToLayer

### DIFF
--- a/k4Reco/GaudiTrkUtils/include/GaudiDDKalTestTrack.h
+++ b/k4Reco/GaudiTrkUtils/include/GaudiDDKalTestTrack.h
@@ -143,6 +143,9 @@ public:
   int propagate(const edm4hep::Vector3d& point, const TKalTrackSite& site, edm4hep::TrackState& ts, double& chi2,
                 int& ndf, const DDVMeasLayer* ml = nullptr);
 
+  // Used by Pandora to propagate the refitted tracks
+  int propagateToLayer(int layerID, edm4hep::TrackState& ts, double& chi2, int& ndf, int& detElementID, int mode);
+
   /** propagate the fit at the measurement site associated with the given hit, to numbered sensitive layer,
    *  returning TrackState, chi2, ndf and integer ID of sensitive detector element via reference
    */

--- a/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
+++ b/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
@@ -730,7 +730,7 @@ int GaudiDDKalTestTrack::propagate(const edm4hep::Vector3d& point, const TKalTra
 
 int GaudiDDKalTestTrack::propagateToLayer(int layerID, edm4hep::TrackState& ts, double& chi2, int& ndf,
                                           int& detElementID, int mode) {
-  const TKalTrackSite& site = *(dynamic_cast<const TKalTrackSite*>(m_kaltrack->Last()));
+  const TKalTrackSite& site = *static_cast<const TKalTrackSite*>(m_kaltrack->Last());
 
   return this->propagateToLayer(layerID, site, ts, chi2, ndf, detElementID, mode);
 }

--- a/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
+++ b/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
@@ -730,7 +730,7 @@ int GaudiDDKalTestTrack::propagate(const edm4hep::Vector3d& point, const TKalTra
 
 int GaudiDDKalTestTrack::propagateToLayer(int layerID, edm4hep::TrackState& ts, double& chi2, int& ndf,
                                           int& detElementID, int mode) {
-  const TKalTrackSite& site = *static_cast<const TKalTrackSite*>(m_kaltrack->Last());
+  const auto& site = *static_cast<const TKalTrackSite*>(m_kaltrack->Last());
 
   return this->propagateToLayer(layerID, site, ts, chi2, ndf, detElementID, mode);
 }

--- a/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
+++ b/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
@@ -728,9 +728,9 @@ int GaudiDDKalTestTrack::propagate(const edm4hep::Vector3d& point, const TKalTra
   return 0;
 }
 
-int GaudiDDKalTestTrack::propagateToLayer(int layerID, edm4hep::TrackState& ts,
-                                          double& chi2, int& ndf, int& detElementID, int mode) {
-  const TKalTrackSite& site = *(dynamic_cast<const TKalTrackSite*>(m_kaltrack->Last())) ;
+int GaudiDDKalTestTrack::propagateToLayer(int layerID, edm4hep::TrackState& ts, double& chi2, int& ndf,
+                                          int& detElementID, int mode) {
+  const TKalTrackSite& site = *(dynamic_cast<const TKalTrackSite*>(m_kaltrack->Last()));
 
   return this->propagateToLayer(layerID, site, ts, chi2, ndf, detElementID, mode);
 }

--- a/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
+++ b/k4Reco/GaudiTrkUtils/src/GaudiDDKalTestTrack.cpp
@@ -728,6 +728,13 @@ int GaudiDDKalTestTrack::propagate(const edm4hep::Vector3d& point, const TKalTra
   return 0;
 }
 
+int GaudiDDKalTestTrack::propagateToLayer(int layerID, edm4hep::TrackState& ts,
+                                          double& chi2, int& ndf, int& detElementID, int mode) {
+  const TKalTrackSite& site = *(dynamic_cast<const TKalTrackSite*>(m_kaltrack->Last())) ;
+
+  return this->propagateToLayer(layerID, site, ts, chi2, ndf, detElementID, mode);
+}
+
 int GaudiDDKalTestTrack::propagateToLayer(int layerID, const edm4hep::TrackerHit* trkhit, edm4hep::TrackState& ts,
                                           double& chi2, int& ndf, int& detElementID, int mode) {
   TKalTrackSite* site = nullptr;


### PR DESCRIPTION
BEGINRELEASENOTES
- Add an overload for Pandora for the member function propagateToLayer that doesn't take any hits and uses the last hit added to the track to get the track measurement and propagate

ENDRELEASENOTES

This overload is used by Pandora for propagating tracks without fitting. There exists another overload that takes an EDM4hep hit and we could pass the last hit that was added to the track to it. However, that doesn't work because that overload will try to get the TKalTrackSite (track measurement) that is only built after fitting, which Pandora does not need since it uses the refitted tracks (for CLD). Already used in https://github.com/key4hep/k4GaudiPandora/pull/16