### PR TITLE
Use KeyValue when possible to define a single input or output

### DIFF
--- a/k4Reco/ConformalTracking/components/ConformalTracking.cpp
+++ b/k4Reco/ConformalTracking/components/ConformalTracking.cpp
@@ -83,7 +83,7 @@ ConformalTracking::ConformalTracking(const std::string& name, ISvcLocator* svcLo
                       KeyValues("RelationsNames", {}),
                   },
                   {
-                      KeyValues("SiTrackCollectionName", {"CATracks"}),
+                      KeyValue("SiTrackCollectionName", "CATracks"),
                   }) {}
 
 StatusCode ConformalTracking::initialize() {

--- a/k4Reco/ConformalTracking/options/runConformalTracking.py
+++ b/k4Reco/ConformalTracking/options/runConformalTracking.py
@@ -68,7 +68,7 @@ tracking.RelationsNames = [
     "OuterTrackerEndcapHitsRelations",
 ]
 tracking.MCParticleCollectionName = ["MCParticles"]
-tracking.SiTrackCollectionName = ["NewSiTracks"]
+tracking.SiTrackCollectionName = "NewSiTracks"
 
 tracking.MainTrackerHitCollectionNames = [
     "ITrackerHits",

--- a/k4Reco/GaudiLumiCalClusterer/components/GaudiLumiCalClusterer.cpp
+++ b/k4Reco/GaudiLumiCalClusterer/components/GaudiLumiCalClusterer.cpp
@@ -34,12 +34,12 @@
 GaudiLumiCalClusterer::GaudiLumiCalClusterer(const std::string& name, ISvcLocator* svcLoc)
     : MultiTransformer(name, svcLoc,
                        {
-                           KeyValues("LumiCal_Collection", {"LumiCalCollection"}),
+                           KeyValue("LumiCal_Collection", "LumiCalCollection"),
                        },
                        {
-                           KeyValues("LumiCal_Hits", {"LumiCalHits"}),
-                           KeyValues("LumiCal_Clusters", {"LumiCalClusters"}),
-                           KeyValues("LumiCal_RecoParticles", {"LumiCalRecoParticles"}),
+                           KeyValue("LumiCal_Hits", "LumiCalHits"),
+                           KeyValue("LumiCal_Clusters", "LumiCalClusters"),
+                           KeyValue("LumiCal_RecoParticles", "LumiCalRecoParticles"),
                        }) {}
 
 StatusCode GaudiLumiCalClusterer::initialize() {

--- a/k4Reco/GaudiLumiCalClusterer/options/runGaudiLumiCalClusterer.py
+++ b/k4Reco/GaudiLumiCalClusterer/options/runGaudiLumiCalClusterer.py
@@ -45,12 +45,12 @@ iosvc.Output = "output_gaudi_lumical_clustering.root"
 clustering = GaudiLumiCalClusterer("GaudiLumiCalClusterer")
 
 # Input collections
-clustering.LumiCal_Collection = ["LumiCalCollection"]
+clustering.LumiCal_Collection = "LumiCalCollection"
 
 # Output collections
-clustering.LumiCal_Hits = ["GaudiLumiCalHits"]
-clustering.LumiCal_Clusters = ["GaudiLumiCalClusters"]
-clustering.LumiCal_RecoParticles = ["GaudiLumiCalRecoParticles"]
+clustering.LumiCal_Hits = "GaudiLumiCalHits"
+clustering.LumiCal_Clusters = "GaudiLumiCalClusters"
+clustering.LumiCal_RecoParticles = "GaudiLumiCalRecoParticles"
 
 clustering.ClusterMinNumHits = 15
 clustering.ElementsPercentInShowerPeakLayer = 0.03

--- a/k4Reco/Overlay/components/OverlayTiming.h
+++ b/k4Reco/Overlay/components/OverlayTiming.h
@@ -49,7 +49,6 @@
 #include "Gaudi/Property.h"
 
 #include <map>
-#include <random>
 #include <string>
 #include <vector>
 
@@ -86,10 +85,10 @@ struct OverlayTiming : public k4FWCore::MultiTransformer<retType(
                            const std::vector<const edm4hep::SimCalorimeterHitCollection*>&)> {
   OverlayTiming(const std::string& name, ISvcLocator* svcLoc)
       : MultiTransformer(name, svcLoc,
-                         {KeyValues("EventHeader", {"EventHeader"}), KeyValues("MCParticles", {"DefaultMCParticles"}),
+                         {KeyValue("EventHeader", {"EventHeader"}), KeyValue("MCParticles", "DefaultMCParticles"),
                           KeyValues("SimTrackerHits", {"DefaultSimTrackerHits"}),
                           KeyValues("SimCalorimeterHits", {"DefaultSimCalorimeterHits"})},
-                         {KeyValues("OutputMCParticles", {"NewMCParticles"}),
+                         {KeyValue("OutputMCParticles", "NewMCParticles"),
                           KeyValues("OutputSimTrackerHits", {"MCParticles1"}),
                           KeyValues("OutputSimCalorimeterHits", {"MCParticles2"}),
                           KeyValues("OutputCaloHitContributions", {"OverlayCaloHitContributions"})}) {}

--- a/k4Reco/Overlay/options/runOverlayTiming.py
+++ b/k4Reco/Overlay/options/runOverlayTiming.py
@@ -41,7 +41,7 @@ iosvc.Output = "output_overlay.root"
 # ]
 
 overlay = OverlayTiming()
-overlay.MCParticles = ["MCParticle"]
+overlay.MCParticles = "MCParticles"
 overlay.SimTrackerHits = ["VertexBarrelCollection", "VertexEndcapCollection"]
 overlay.SimCalorimeterHits = ["HCalRingCollection"]
 overlay.BackgroundMCParticleCollectionName = "MCParticle"

--- a/k4Reco/Tracking/options/runClonesAndSplitTracksFinder.py
+++ b/k4Reco/Tracking/options/runClonesAndSplitTracksFinder.py
@@ -47,8 +47,8 @@ iosvc.Output = "output_clones_and_split_tracks_finder.root"
 
 ClonesAndSplitTracksFinder = ClonesAndSplitTracksFinder(
     "ClonesAndSplitTracksFinder",
-    InputTrackCollectionName=["SiTracksCT"],
-    OutputTrackCollectionName=["GaudiSiTracks"],
+    InputTrackCollectionName="SiTracksCT",
+    OutputTrackCollectionName="GaudiSiTracks",
     EnergyLossOn=True,
     MultipleScatteringOn=True,
     SmoothOn=False,

--- a/k4Reco/Tracking/options/runRefitFinal.py
+++ b/k4Reco/Tracking/options/runRefitFinal.py
@@ -47,10 +47,10 @@ iosvc.Output = "output_refit_final.root"
 
 RefitFinal = RefitFinal(
     "RefitFinal",
-    InputTrackCollectionName=["SiTracks"],
+    InputTrackCollectionName="SiTracks",
     InputRelationCollectionName=[],
-    OutputTrackCollectionName=["GaudiSiTracks_Refitted"],
-    OutputRelationCollectionName=["GaudiSiTracks_Refitted_Relation"],
+    OutputTrackCollectionName="GaudiSiTracks_Refitted",
+    OutputRelationCollectionName="GaudiSiTracks_Refitted_Relation",
     EnergyLossOn=True,
     Max_Chi2_Incr=1.79769e30,
     MinClustersOnTrackAfterFit=3,

--- a/k4Reco/Tracking/options/runTruthTrackFinder.py
+++ b/k4Reco/Tracking/options/runTruthTrackFinder.py
@@ -48,8 +48,8 @@ iosvc.Output = "output_truth_track_finder.root"
 truth_track_finder = TruthTrackFinder(
     "TruthTrackFinder",
     MCParticleCollectionName=["MCParticles"],
-    SiTrackCollectionName=["GaudiSiTracks"],
-    SiTrackRelationCollectionName=["GaudiSiTrackRelations"],
+    SiTrackCollectionName="GaudiSiTracks",
+    SiTrackRelationCollectionName="GaudiSiTrackRelations",
     SimTrackerHitRelCollectionNames=["VXDTrackerHitRelations", "InnerTrackerBarrelHitsRelations", "OuterTrackerBarrelHitsRelations", "VXDEndcapTrackerHitRelations", "InnerTrackerEndcapHitsRelations", "OuterTrackerEndcapHitsRelations"],
     TrackerHitCollectionNames=["VXDTrackerHits", "ITrackerHits", "OTrackerHits", "VXDEndcapTrackerHits", "ITrackerEndcapHits", "OTrackerEndcapHits"],
     UseTruthInPrefit=False,

--- a/k4Reco/Tracking/src/ClonesAndSplitTracksFinder.cpp
+++ b/k4Reco/Tracking/src/ClonesAndSplitTracksFinder.cpp
@@ -36,10 +36,10 @@
 ClonesAndSplitTracksFinder::ClonesAndSplitTracksFinder(const std::string& name, ISvcLocator* svcLoc)
     : Transformer(name, svcLoc,
                   {
-                      KeyValues("InputTrackCollectionName", {"SiTracks"}),
+                      KeyValue("InputTrackCollectionName", "SiTracks"),
                   },
                   {
-                      KeyValues("OutputTrackCollectionName", {"SiTracksMerged"}),
+                      KeyValue("OutputTrackCollectionName", "SiTracksMerged"),
                   }) {}
 
 StatusCode ClonesAndSplitTracksFinder::initialize() {

--- a/k4Reco/Tracking/src/RefitFinal.cpp
+++ b/k4Reco/Tracking/src/RefitFinal.cpp
@@ -34,15 +34,16 @@
 #include <string>
 
 RefitFinal::RefitFinal(const std::string& name, ISvcLocator* svcLoc)
-    : MultiTransformer(name, svcLoc,
-                       {
-                           KeyValues("InputTrackCollectionName", {"TruthTracks"}),
-                           KeyValues("InputRelationCollectionName", {"SiTrackRelations"}),
-                       },
-                       {
-                           KeyValues("OutputTrackCollectionName", {"RefittedTracks"}),
-                           KeyValues("OutputRelationCollectionName", {"RefittedRelation"}),
-                       }) {}
+    : MultiTransformer(
+          name, svcLoc,
+          {
+              KeyValue("InputTrackCollectionName", "TruthTracks"),
+              KeyValues("InputRelationCollectionName", {"SiTrackRelations"}), // KeyValues so that it can be empty
+          },
+          {
+              KeyValue("OutputTrackCollectionName", "RefittedTracks"),
+              KeyValue("OutputRelationCollectionName", "RefittedRelation"),
+          }) {}
 
 StatusCode RefitFinal::initialize() {
   // Setting the streamlog output is necessary to avoid lots of overhead.

--- a/k4Reco/Tracking/src/TruthTrackFinder.cpp
+++ b/k4Reco/Tracking/src/TruthTrackFinder.cpp
@@ -88,8 +88,8 @@ TruthTrackFinder::TruthTrackFinder(const std::string& name, ISvcLocator* svcLoc)
                            KeyValues("MCParticleCollectionName", {"MCParticle"}),
                        },
                        {
-                           KeyValues("SiTrackCollectionName", {"SiTracks"}),
-                           KeyValues("SiTrackRelationCollectionName", {"SiTrackRelations"}),
+                           KeyValue("SiTrackCollectionName", "SiTracks"),
+                           KeyValue("SiTrackRelationCollectionName", "SiTrackRelations"),
                        }) {}
 
 StatusCode TruthTrackFinder::initialize() {


### PR DESCRIPTION
BEGINRELEASENOTES
- Use KeyValue when possible to define a single input or output. This is an example of the changes that can be done after https://github.com/key4hep/k4FWCore/pull/345 for most algorithms here.

ENDRELEASENOTES

I leave `DDPlanarDigi` since I would have to have a look where it is used.