### PR TITLE
remove compatibility with older Gaudi versions

### DIFF
--- a/k4Reco/ConformalTracking/components/ConformalTracking.h
+++ b/k4Reco/ConformalTracking/components/ConformalTracking.h
@@ -37,16 +37,6 @@
 #include <Gaudi/Accumulators/RootHistogram.h>
 #include <Gaudi/Property.h>
 
-#include "GAUDI_VERSION.h"
-
-#if GAUDI_MAJOR_VERSION < 39
-namespace Gaudi::Accumulators {
-template <unsigned int ND, atomicity Atomicity = atomicity::full, typename Arithmetic = double>
-using StaticRootHistogram =
-    Gaudi::Accumulators::RootHistogramingCounterBase<ND, Atomicity, Arithmetic, naming::histogramString>;
-}
-#endif
-
 #include <TCanvas.h>
 #include <TH1F.h>
 #include <TH2F.h>

--- a/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
+++ b/k4Reco/DDPlanarDigi/components/DDPlanarDigi.h
@@ -38,21 +38,11 @@
 #include <string>
 #include <vector>
 
-#include "GAUDI_VERSION.h"
-
-#if GAUDI_MAJOR_VERSION < 39
-namespace Gaudi::Accumulators {
-template <unsigned int ND, atomicity Atomicity = atomicity::full, typename Arithmetic = double>
-using StaticRootHistogram =
-    Gaudi::Accumulators::RootHistogramingCounterBase<ND, Atomicity, Arithmetic, naming::histogramString>;
-}
-#endif
-
 /** ======= DDPlanarDigi ========== <br>
  * Creates TrackerHits from SimTrackerHits, smearing them according to the input parameters.
  * The positions of "digitized" TrackerHits are obtained by gaussian smearing positions
  * of SimTrackerHits perpendicular and along the ladder according to the specified point resolutions.
- * The geometry of the surface is retreived from DDRec::Surface associated to the hit via cellID.
+ * The geometry of the surface is retrieved from DDRec::Surface associated to the hit via cellID.
  *
  *
  * <h4>Input collections and prerequisites</h4>


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove histogram interface compatibility with Gaudi versions older that v39

ENDRELEASENOTES

Both the nigthlies and the current release (2026-02-01) have Gaudi  newer than 39.

See https://github.com/key4hep/k4FWCore/pull/378