### PR TITLE
Switch to overload taking the algorithm as argument

### DIFF
--- a/k4Reco/GaudiLumiCalClusterer/components/GaudiLumiCalClusterer.cpp
+++ b/k4Reco/GaudiLumiCalClusterer/components/GaudiLumiCalClusterer.cpp
@@ -52,8 +52,7 @@ StatusCode GaudiLumiCalClusterer::initialize() {
 
   m_lumiCalClusterer = std::make_unique<LumiCalClustererClass>(this, m_geoSvc);
 
-  const auto maybeParam = k4FWCore::getParameter<std::string>(inputLocations(0)[0] + "__CellIDEncoding");
-  const auto initString = maybeParam.value();
+  const auto initString = k4FWCore::getCellIDEncoding(inputLocations(0)[0], this).value();
 
   m_lumiCalClusterer->createDecoder(initString);
 


### PR DESCRIPTION
In turn also directly switching to the dedicated utility for cell ID encoding strings


BEGINRELEASENOTES
- Remove deprecated call to `k4FWCore::getParameter` without passing `this`
- Switch to new `getCellIDEncoding` functionality

ENDRELEASENOTES

- [x] Needs https://github.com/key4hep/k4FWCore/pull/391


