### PR TITLE
Minor cleanup to tests and their interdependencies

### DIFF
--- a/k4Reco/GaudiLumiCalClusterer/scripts/compare-lumical.py
+++ b/k4Reco/GaudiLumiCalClusterer/scripts/compare-lumical.py
@@ -171,7 +171,7 @@ for i, frame_gaudi in enumerate(events_gaudi):
             ]:
                 assert (
                     getattr(hit_gaudi, f"get{attr}")() == getattr(hit_marlin, f"get{attr}")()
-                ), f"{attr} differ for hit {j}: {getattr(hit_gaudi, f'get{attr}')()} vs {getattr(hit_marlin, f'get{attr}')()}"
+                ), f"{attr} differ for particle {j}: {getattr(hit_gaudi, f'get{attr}')()} vs {getattr(hit_marlin, f'get{attr}')()}"
 
 
             for relation in [
@@ -180,7 +180,7 @@ for i, frame_gaudi in enumerate(events_gaudi):
                 assert (
                     getattr(hit_gaudi, f"get{relation}")().id().index ==
                     getattr(hit_marlin, f"get{relation}")().id().index
-                ), f"{relation} differ for hit {j}: {getattr(hit_gaudi, f'get{relation}')()} vs {getattr(hit_marlin, f'get{relation}')()}"
+                ), f"{relation} differ for particle {j}: {getattr(hit_gaudi, f'get{relation}')()} vs {getattr(hit_marlin, f'get{relation}')()}"
 
             for relation in [
                 "Clusters",
@@ -190,4 +190,4 @@ for i, frame_gaudi in enumerate(events_gaudi):
                 assert (
                     [elem.id().index for elem in getattr(hit_gaudi, f"get{relation}")()] ==
                     [elem.id().index for elem in getattr(hit_marlin, f"get{relation}")()]
-                ), f"{relation} differ for hit {j}: {getattr(hit_gaudi, f'get{relation}')()} vs {getattr(hit_marlin, f'get{relation}')()}"
+                ), f"{relation} differ for particle {j}: {getattr(hit_gaudi, f'get{relation}')()} vs {getattr(hit_marlin, f'get{relation}')()}"

--- a/k4Reco/GaudiLumiCalClusterer/scripts/compare-lumical.py
+++ b/k4Reco/GaudiLumiCalClusterer/scripts/compare-lumical.py
@@ -124,7 +124,7 @@ for i, frame_gaudi in enumerate(events_gaudi):
                 "Position",
                 "PositionError",
                 "ITheta",
-                "Phi",
+                "IPhi",
                 "DirectionError",
             ]:
                 assert (

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ function(set_test_env testname)
 endfunction()
 
 add_test(NAME "clone_CLDConfig"
-  COMMAND bash -c "git clone https://github.com/key4hep/CLDConfig.git --depth 1 && cp -r CLDConfig/CLDConfig/* . && sed -i -e '/Overlay.Overlay/d' -e '/HighLevelReco.RecoMCTruthLink/d' CLDReconstruction.py"
+  COMMAND bash -c "if [ ! -d CLDConfig ]; then git clone https://github.com/key4hep/CLDConfig.git --depth 1; fi && cp -r CLDConfig/CLDConfig/* . && sed -i -e '/Overlay.Overlay/d' -e '/HighLevelReco.RecoMCTruthLink/d' CLDReconstruction.py"
 )
 set_test_env("clone_CLDConfig")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,13 +29,13 @@ add_test(NAME "clone_CLDConfig"
   COMMAND bash -c "if [ ! -d CLDConfig ]; then git clone https://github.com/key4hep/CLDConfig.git --depth 1; fi && cp -r CLDConfig/CLDConfig/* . && sed -i -e '/Overlay.Overlay/d' -e '/HighLevelReco.RecoMCTruthLink/d' CLDReconstruction.py"
 )
 set_test_env("clone_CLDConfig")
-set_tests_properties("clone_CLDConfig" PROPERTIES FIXTURES_SETUP CLDConfig_fixture)
+set_tests_properties("clone_CLDConfig" PROPERTIES FIXTURES_SETUP CLDConfig)
 
 add_test(NAME "run_ddsim"
   COMMAND bash -c "ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G --numberOfEvents 3 --outputFile sim.edm4hep.root --gun.energy '10*GeV' --gun.particle 'mu-' --gun.distribution uniform --gun.multiplicity 10"
   )
 set_test_env("run_ddsim")
-set_tests_properties("run_ddsim" PROPERTIES FIXTURES_SETUP SimOutput_fixture)
+set_tests_properties("run_ddsim" PROPERTIES FIXTURES_SETUP SimOutput)
 
 # If this is modified, make sure that this simulations produces clusters and reconstructed particles in the LumiCal
 # as this doesn't always happen with the current setting (but does for the current seed)
@@ -43,45 +43,45 @@ add_test(NAME "run_ddsim_LumiCal"
   COMMAND bash -c "ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G --numberOfEvents 3 --outputFile sim_lumical.edm4hep.root --gun.energy '50*GeV' --gun.particle 'gamma' --gun.distribution uniform --gun.multiplicity 10 --gun.thetaMin='50*mrad' --gun.thetaMax='100*mrad'"
   )
 set_test_env("run_ddsim_LumiCal")
-set_tests_properties("run_ddsim_LumiCal" PROPERTIES FIXTURES_SETUP SimLumiCalOutput_fixture)
+set_tests_properties("run_ddsim_LumiCal" PROPERTIES FIXTURES_SETUP SimLumiCalOutput)
 
 add_test(NAME "run_marlin_wrapper_truth_tracking"
   COMMAND k4run CLDReconstruction.py --inputFiles sim.edm4hep.root --trackingOnly --truthTracking --outputBasename output_truth_tracking
 )
 set_test_env("run_marlin_wrapper_truth_tracking")
 set_tests_properties("run_marlin_wrapper_truth_tracking" PROPERTIES
-  FIXTURES_REQUIRED "CLDConfig_fixture;SimOutput_fixture"
-  FIXTURES_SETUP TruthTrackingOutput_fixture)
+  FIXTURES_REQUIRED "CLDConfig;SimOutput"
+  FIXTURES_SETUP TruthTrackingOutput)
 
 add_test(NAME "run_wrapper"
   COMMAND k4run CLDReconstruction.py --inputFiles sim.edm4hep.root --trackingOnly
 )
 set_test_env("run_wrapper")
 set_tests_properties("run_wrapper" PROPERTIES
-  FIXTURES_REQUIRED "CLDConfig_fixture;SimOutput_fixture"
-  FIXTURES_SETUP WrapperOutput_fixture)
+  FIXTURES_REQUIRED "CLDConfig;SimOutput"
+  FIXTURES_SETUP WrapperOutput)
 
 add_test(NAME "run_wrapper_LumiCal"
   COMMAND k4run CLDReconstruction.py --inputFiles sim_lumical.edm4hep.root --outputBasename output_lumical
 )
 set_test_env("run_wrapper_LumiCal")
 set_tests_properties("run_wrapper_LumiCal" PROPERTIES
-  FIXTURES_REQUIRED "CLDConfig_fixture;SimLumiCalOutput_fixture"
-  FIXTURES_SETUP WrapperLumiCalOutput_fixture)
+  FIXTURES_REQUIRED "CLDConfig;SimLumiCalOutput"
+  FIXTURES_SETUP WrapperLumiCalOutput)
 
 add_test(NAME "run_GaudiLumiCalClusterer"
   COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/GaudiLumiCalClusterer/options/runGaudiLumiCalClusterer.py --IOSvc.Input output_lumical_REC.edm4hep.root
 )
 set_test_env("run_GaudiLumiCalClusterer")
 set_tests_properties("run_GaudiLumiCalClusterer" PROPERTIES
-  FIXTURES_REQUIRED "WrapperLumiCalOutput_fixture"
-  FIXTURES_SETUP GaudiLumiCalOutput_fixture)
+  FIXTURES_REQUIRED "WrapperLumiCalOutput"
+  FIXTURES_SETUP GaudiLumiCalOutput)
 
 add_test(NAME "compare_LumiCalClusterer"
   COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/GaudiLumiCalClusterer/scripts/compare-lumical.py"
 )
 set_test_env("compare_LumiCalClusterer")
-set_tests_properties("compare_LumiCalClusterer" PROPERTIES FIXTURES_REQUIRED "WrapperLumiCalOutput_fixture;GaudiLumiCalOutput_fixture")
+set_tests_properties("compare_LumiCalClusterer" PROPERTIES FIXTURES_REQUIRED "WrapperLumiCalOutput;GaudiLumiCalOutput")
 
 if(BUILD_TRACKING)
 
@@ -90,55 +90,55 @@ if(BUILD_TRACKING)
   )
   set_test_env("run_ConformalTracking")
   set_tests_properties("run_ConformalTracking" PROPERTIES
-    FIXTURES_REQUIRED "WrapperOutput_fixture"
-    FIXTURES_SETUP ConformalTrackingOutput_fixture)
+    FIXTURES_REQUIRED "WrapperOutput"
+    FIXTURES_SETUP ConformalTrackingOutput)
 
   add_test(NAME "compare_ConformalTracking"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py"
   )
   set_test_env("compare_ConformalTracking")
-  set_tests_properties("compare_ConformalTracking" PROPERTIES FIXTURES_REQUIRED "ConformalTrackingOutput_fixture")
+  set_tests_properties("compare_ConformalTracking" PROPERTIES FIXTURES_REQUIRED "ConformalTrackingOutput")
 
   add_test(NAME "run_ClonesAndSplitTracksFinder"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runClonesAndSplitTracksFinder.py
   )
   set_test_env("run_ClonesAndSplitTracksFinder")
   set_tests_properties("run_ClonesAndSplitTracksFinder" PROPERTIES
-    FIXTURES_REQUIRED "WrapperOutput_fixture"
-    FIXTURES_SETUP ClonesAndSplitTracksFinderOutput_fixture)
+    FIXTURES_REQUIRED "WrapperOutput"
+    FIXTURES_SETUP ClonesAndSplitTracksFinderOutput)
 
   add_test(NAME "compare_ClonesAndSplitTracksFinder"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --gaudi-file output_clones_and_split_tracks_finder.root --marlin-tracks SiTracks --gaudi-tracks GaudiSiTracks
   )
   set_test_env("compare_ClonesAndSplitTracksFinder")
-  set_tests_properties("compare_ClonesAndSplitTracksFinder" PROPERTIES FIXTURES_REQUIRED "ClonesAndSplitTracksFinderOutput_fixture")
+  set_tests_properties("compare_ClonesAndSplitTracksFinder" PROPERTIES FIXTURES_REQUIRED "ClonesAndSplitTracksFinderOutput")
 
   add_test(NAME "run_RefitFinal"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runRefitFinal.py
   )
   set_test_env("run_RefitFinal")
   set_tests_properties("run_RefitFinal" PROPERTIES
-    FIXTURES_REQUIRED "WrapperOutput_fixture"
-    FIXTURES_SETUP RefitFinalOutput_fixture)
+    FIXTURES_REQUIRED "WrapperOutput"
+    FIXTURES_SETUP RefitFinalOutput)
 
   add_test(NAME "compare_RefitFinal"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --gaudi-file output_refit_final.root --marlin-tracks SiTracks_Refitted --gaudi-tracks GaudiSiTracks_Refitted
   )
   set_test_env("compare_RefitFinal")
-  set_tests_properties("compare_RefitFinal" PROPERTIES FIXTURES_REQUIRED "RefitFinalOutput_fixture")
+  set_tests_properties("compare_RefitFinal" PROPERTIES FIXTURES_REQUIRED "RefitFinalOutput")
 
   add_test(NAME "run_TruthTrackFinder"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runTruthTrackFinder.py
   )
   set_test_env("run_TruthTrackFinder")
   set_tests_properties("run_TruthTrackFinder" PROPERTIES
-    FIXTURES_REQUIRED "TruthTrackingOutput_fixture"
-    FIXTURES_SETUP TruthTrackFinderOutput_fixture)
+    FIXTURES_REQUIRED "TruthTrackingOutput"
+    FIXTURES_SETUP TruthTrackFinderOutput)
 
   add_test(NAME "compare_TruthTrackFinder"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --marlin-file output_truth_tracking_REC.edm4hep.root --gaudi-file output_truth_track_finder.root --marlin-tracks SiTracks --gaudi-tracks GaudiSiTracks
   )
   set_test_env("compare_TruthTrackFinder")
-  set_tests_properties("compare_TruthTrackFinder" PROPERTIES FIXTURES_REQUIRED "TruthTrackFinderOutput_fixture")
+  set_tests_properties("compare_TruthTrackFinder" PROPERTIES FIXTURES_REQUIRED "TruthTrackFinderOutput")
 
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,11 +29,13 @@ add_test(NAME "clone_CLDConfig"
   COMMAND bash -c "if [ ! -d CLDConfig ]; then git clone https://github.com/key4hep/CLDConfig.git --depth 1; fi && cp -r CLDConfig/CLDConfig/* . && sed -i -e '/Overlay.Overlay/d' -e '/HighLevelReco.RecoMCTruthLink/d' CLDReconstruction.py"
 )
 set_test_env("clone_CLDConfig")
+set_tests_properties("clone_CLDConfig" PROPERTIES FIXTURES_SETUP CLDConfig_fixture)
 
 add_test(NAME "run_ddsim"
   COMMAND bash -c "ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G --numberOfEvents 3 --outputFile sim.edm4hep.root --gun.energy '10*GeV' --gun.particle 'mu-' --gun.distribution uniform --gun.multiplicity 10"
   )
 set_test_env("run_ddsim")
+set_tests_properties("run_ddsim" PROPERTIES FIXTURES_SETUP SimOutput_fixture)
 
 # If this is modified, make sure that this simulations produces clusters and reconstructed particles in the LumiCal
 # as this doesn't always happen with the current setting (but does for the current seed)
@@ -41,36 +43,45 @@ add_test(NAME "run_ddsim_LumiCal"
   COMMAND bash -c "ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G --numberOfEvents 3 --outputFile sim_lumical.edm4hep.root --gun.energy '50*GeV' --gun.particle 'gamma' --gun.distribution uniform --gun.multiplicity 10 --gun.thetaMin='50*mrad' --gun.thetaMax='100*mrad'"
   )
 set_test_env("run_ddsim_LumiCal")
+set_tests_properties("run_ddsim_LumiCal" PROPERTIES FIXTURES_SETUP SimLumiCalOutput_fixture)
 
 add_test(NAME "run_marlin_wrapper_truth_tracking"
   COMMAND k4run CLDReconstruction.py --inputFiles sim.edm4hep.root --trackingOnly --truthTracking --outputBasename output_truth_tracking
 )
 set_test_env("run_marlin_wrapper_truth_tracking")
-set_tests_properties("run_marlin_wrapper_truth_tracking" PROPERTIES DEPENDS "clone_CLDConfig;run_ddsim")
+set_tests_properties("run_marlin_wrapper_truth_tracking" PROPERTIES
+  FIXTURES_REQUIRED "CLDConfig_fixture;SimOutput_fixture"
+  FIXTURES_SETUP TruthTrackingOutput_fixture)
 
 add_test(NAME "run_wrapper"
   COMMAND k4run CLDReconstruction.py --inputFiles sim.edm4hep.root --trackingOnly
 )
 set_test_env("run_wrapper")
-set_tests_properties("run_wrapper" PROPERTIES DEPENDS "clone_CLDConfig;run_ddsim")
+set_tests_properties("run_wrapper" PROPERTIES
+  FIXTURES_REQUIRED "CLDConfig_fixture;SimOutput_fixture"
+  FIXTURES_SETUP WrapperOutput_fixture)
 
 add_test(NAME "run_wrapper_LumiCal"
   COMMAND k4run CLDReconstruction.py --inputFiles sim_lumical.edm4hep.root --outputBasename output_lumical
 )
 set_test_env("run_wrapper_LumiCal")
-set_tests_properties("run_wrapper_LumiCal" PROPERTIES DEPENDS "clone_CLDConfig;run_ddsim_LumiCal")
+set_tests_properties("run_wrapper_LumiCal" PROPERTIES
+  FIXTURES_REQUIRED "CLDConfig_fixture;SimLumiCalOutput_fixture"
+  FIXTURES_SETUP WrapperLumiCalOutput_fixture)
 
 add_test(NAME "run_GaudiLumiCalClusterer"
   COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/GaudiLumiCalClusterer/options/runGaudiLumiCalClusterer.py --IOSvc.Input output_lumical_REC.edm4hep.root
 )
 set_test_env("run_GaudiLumiCalClusterer")
-set_tests_properties("run_GaudiLumiCalClusterer" PROPERTIES DEPENDS "clone_CLDConfig;run_wrapper_LumiCal")
+set_tests_properties("run_GaudiLumiCalClusterer" PROPERTIES
+  FIXTURES_REQUIRED "WrapperLumiCalOutput_fixture"
+  FIXTURES_SETUP GaudiLumiCalOutput_fixture)
 
 add_test(NAME "compare_LumiCalClusterer"
   COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/GaudiLumiCalClusterer/scripts/compare-lumical.py"
 )
 set_test_env("compare_LumiCalClusterer")
-set_tests_properties("compare_LumiCalClusterer" PROPERTIES DEPENDS "run_wrapper_LumiCal;run_GaudiLumiCalClusterer")
+set_tests_properties("compare_LumiCalClusterer" PROPERTIES FIXTURES_REQUIRED "WrapperLumiCalOutput_fixture;GaudiLumiCalOutput_fixture")
 
 if(BUILD_TRACKING)
 
@@ -78,54 +89,56 @@ if(BUILD_TRACKING)
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/options/runConformalTracking.py
   )
   set_test_env("run_ConformalTracking")
-  set_tests_properties("run_ConformalTracking" PROPERTIES DEPENDS "run_wrapper")
+  set_tests_properties("run_ConformalTracking" PROPERTIES
+    FIXTURES_REQUIRED "WrapperOutput_fixture"
+    FIXTURES_SETUP ConformalTrackingOutput_fixture)
 
   add_test(NAME "compare_ConformalTracking"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py"
   )
   set_test_env("compare_ConformalTracking")
-  set_tests_properties("compare_ConformalTracking" PROPERTIES DEPENDS "run_ConformalTracking")
+  set_tests_properties("compare_ConformalTracking" PROPERTIES FIXTURES_REQUIRED "ConformalTrackingOutput_fixture")
 
   add_test(NAME "run_ClonesAndSplitTracksFinder"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runClonesAndSplitTracksFinder.py
   )
   set_test_env("run_ClonesAndSplitTracksFinder")
-  set_tests_properties("run_ClonesAndSplitTracksFinder" PROPERTIES DEPENDS "run_wrapper")
+  set_tests_properties("run_ClonesAndSplitTracksFinder" PROPERTIES FIXTURES_REQUIRED "WrapperOutput_fixture")
 
   add_test(NAME "compare_ClonesAndSplitTracksFinder"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --gaudi-file output_clones_and_split_tracks_finder.root --marlin-tracks SiTracks --gaudi-tracks GaudiSiTracks
   )
   set_test_env("compare_ClonesAndSplitTracksFinder")
-  set_tests_properties("compare_ClonesAndSplitTracksFinder" PROPERTIES DEPENDS "run_ConformalTracking")
+  set_tests_properties("compare_ClonesAndSplitTracksFinder" PROPERTIES FIXTURES_REQUIRED "ConformalTrackingOutput_fixture")
 
   add_test(NAME "run_RefitFinal"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runRefitFinal.py
   )
   set_test_env("run_RefitFinal")
-  set_tests_properties("run_RefitFinal" PROPERTIES DEPENDS "run_wrapper")
+  set_tests_properties("run_RefitFinal" PROPERTIES FIXTURES_REQUIRED "WrapperOutput_fixture")
 
   add_test(NAME "compare_RefitFinal"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --gaudi-file output_refit_final.root --marlin-tracks SiTracks_Refitted --gaudi-tracks GaudiSiTracks_Refitted
   )
   set_test_env("compare_RefitFinal")
-  set_tests_properties("compare_RefitFinal" PROPERTIES DEPENDS "run_ConformalTracking")
+  set_tests_properties("compare_RefitFinal" PROPERTIES FIXTURES_REQUIRED "ConformalTrackingOutput_fixture")
 
   add_test(NAME "run_wrapper_TruthTracking"
     COMMAND k4run CLDConfig/CLDConfig/CLDReconstruction.py --inputFiles sim.edm4hep.root --trackingOnly --truthTracking --outputBasename output_truth_tracking
   )
   set_test_env("run_wrapper_TruthTracking")
-  set_tests_properties("run_wrapper_TruthTracking" PROPERTIES DEPENDS "clone_CLDConfig;run_ddsim")
+  set_tests_properties("run_wrapper_TruthTracking" PROPERTIES FIXTURES_REQUIRED "CLDConfig_fixture;SimOutput_fixture")
 
   add_test(NAME "run_TruthTrackFinder"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runTruthTrackFinder.py
   )
   set_test_env("run_TruthTrackFinder")
-  set_tests_properties("run_TruthTrackFinder" PROPERTIES DEPENDS "run_marlin_wrapper_truth_tracking")
+  set_tests_properties("run_TruthTrackFinder" PROPERTIES FIXTURES_REQUIRED "TruthTrackingOutput_fixture")
 
   add_test(NAME "compare_TruthTrackFinder"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --marlin-file output_truth_tracking_REC.edm4hep.root --gaudi-file output_truth_track_finder.root --marlin-tracks SiTracks --gaudi-tracks GaudiSiTracks
   )
   set_test_env("compare_TruthTrackFinder")
-  set_tests_properties("compare_TruthTrackFinder" PROPERTIES DEPENDS "run_ConformalTracking")
+  set_tests_properties("compare_TruthTrackFinder" PROPERTIES FIXTURES_REQUIRED "ConformalTrackingOutput_fixture")
 
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -103,25 +103,29 @@ if(BUILD_TRACKING)
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runClonesAndSplitTracksFinder.py
   )
   set_test_env("run_ClonesAndSplitTracksFinder")
-  set_tests_properties("run_ClonesAndSplitTracksFinder" PROPERTIES FIXTURES_REQUIRED "WrapperOutput_fixture")
+  set_tests_properties("run_ClonesAndSplitTracksFinder" PROPERTIES
+    FIXTURES_REQUIRED "WrapperOutput_fixture"
+    FIXTURES_SETUP ClonesAndSplitTracksFinderOutput_fixture)
 
   add_test(NAME "compare_ClonesAndSplitTracksFinder"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --gaudi-file output_clones_and_split_tracks_finder.root --marlin-tracks SiTracks --gaudi-tracks GaudiSiTracks
   )
   set_test_env("compare_ClonesAndSplitTracksFinder")
-  set_tests_properties("compare_ClonesAndSplitTracksFinder" PROPERTIES FIXTURES_REQUIRED "ConformalTrackingOutput_fixture")
+  set_tests_properties("compare_ClonesAndSplitTracksFinder" PROPERTIES FIXTURES_REQUIRED "ClonesAndSplitTracksFinderOutput_fixture")
 
   add_test(NAME "run_RefitFinal"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runRefitFinal.py
   )
   set_test_env("run_RefitFinal")
-  set_tests_properties("run_RefitFinal" PROPERTIES FIXTURES_REQUIRED "WrapperOutput_fixture")
+  set_tests_properties("run_RefitFinal" PROPERTIES
+    FIXTURES_REQUIRED "WrapperOutput_fixture"
+    FIXTURES_SETUP RefitFinalOutput_fixture)
 
   add_test(NAME "compare_RefitFinal"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --gaudi-file output_refit_final.root --marlin-tracks SiTracks_Refitted --gaudi-tracks GaudiSiTracks_Refitted
   )
   set_test_env("compare_RefitFinal")
-  set_tests_properties("compare_RefitFinal" PROPERTIES FIXTURES_REQUIRED "ConformalTrackingOutput_fixture")
+  set_tests_properties("compare_RefitFinal" PROPERTIES FIXTURES_REQUIRED "RefitFinalOutput_fixture")
 
   add_test(NAME "run_wrapper_TruthTracking"
     COMMAND k4run CLDConfig/CLDConfig/CLDReconstruction.py --inputFiles sim.edm4hep.root --trackingOnly --truthTracking --outputBasename output_truth_tracking
@@ -133,12 +137,14 @@ if(BUILD_TRACKING)
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runTruthTrackFinder.py
   )
   set_test_env("run_TruthTrackFinder")
-  set_tests_properties("run_TruthTrackFinder" PROPERTIES FIXTURES_REQUIRED "TruthTrackingOutput_fixture")
+  set_tests_properties("run_TruthTrackFinder" PROPERTIES
+    FIXTURES_REQUIRED "TruthTrackingOutput_fixture"
+    FIXTURES_SETUP TruthTrackFinderOutput_fixture)
 
   add_test(NAME "compare_TruthTrackFinder"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --marlin-file output_truth_tracking_REC.edm4hep.root --gaudi-file output_truth_track_finder.root --marlin-tracks SiTracks --gaudi-tracks GaudiSiTracks
   )
   set_test_env("compare_TruthTrackFinder")
-  set_tests_properties("compare_TruthTrackFinder" PROPERTIES FIXTURES_REQUIRED "ConformalTrackingOutput_fixture")
+  set_tests_properties("compare_TruthTrackFinder" PROPERTIES FIXTURES_REQUIRED "TruthTrackFinderOutput_fixture")
 
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -127,12 +127,6 @@ if(BUILD_TRACKING)
   set_test_env("compare_RefitFinal")
   set_tests_properties("compare_RefitFinal" PROPERTIES FIXTURES_REQUIRED "RefitFinalOutput_fixture")
 
-  add_test(NAME "run_wrapper_TruthTracking"
-    COMMAND k4run CLDConfig/CLDConfig/CLDReconstruction.py --inputFiles sim.edm4hep.root --trackingOnly --truthTracking --outputBasename output_truth_tracking
-  )
-  set_test_env("run_wrapper_TruthTracking")
-  set_tests_properties("run_wrapper_TruthTracking" PROPERTIES FIXTURES_REQUIRED "CLDConfig_fixture;SimOutput_fixture")
-
   add_test(NAME "run_TruthTrackFinder"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runTruthTrackFinder.py
   )


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the `clone_CLDConfig` test work on repeated calls
- Fix a deprecation warning in one of the comparison scripts
- Replace test dependencies using `DEPENDS` with proper fixtures

ENDRELEASENOTES

This does not fix the issue with the lumi cal related tests (#53) for me yet.
