### PR TITLE
Cleanup the test environment

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,16 +23,9 @@ find_package(k4geo REQUIRED)
 set(_test_environment "\
 LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}:\
 ${PROJECT_BINARY_DIR}/${PROJECT_NAME}:\
-${PROJECT_BINARY_DIR}/${PROJECT_NAME}/genConfDir/${PROJECT_NAME}:\
-${PROJECT_BINARY_DIR}/test/k4FWCoreTest:\
-${PROJECT_BINARY_DIR}/test/k4FWCoreTest/genConfDir/k4FWCoreTest:\
-$<$<TARGET_EXISTS:ROOT::Core>:$<TARGET_FILE_DIR:ROOT::Core>>:\
-$<$<TARGET_EXISTS:EDM4HEP::edm4hep>:$<TARGET_FILE_DIR:EDM4HEP::edm4hep>>:\
-$<$<TARGET_EXISTS:podio::podio>:$<TARGET_FILE_DIR:podio::podio>>:\
 $ENV{LD_LIBRARY_PATH};\
 PYTHONPATH=${PROJECT_SOURCE_DIR}/python:\
 ${PROJECT_BINARY_DIR}/${PROJECT_NAME}/genConfDir:\
-/${PROJECT_NAME}/genConfDir:\
 $ENV{PYTHONPATH}")
 
 function(set_test_env testname)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,9 +20,23 @@ limitations under the License.
 
 find_package(k4geo REQUIRED)
 
+set(_test_environment "\
+LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}:\
+${PROJECT_BINARY_DIR}/${PROJECT_NAME}:\
+${PROJECT_BINARY_DIR}/${PROJECT_NAME}/genConfDir/${PROJECT_NAME}:\
+${PROJECT_BINARY_DIR}/test/k4FWCoreTest:\
+${PROJECT_BINARY_DIR}/test/k4FWCoreTest/genConfDir/k4FWCoreTest:\
+$<$<TARGET_EXISTS:ROOT::Core>:$<TARGET_FILE_DIR:ROOT::Core>>:\
+$<$<TARGET_EXISTS:EDM4HEP::edm4hep>:$<TARGET_FILE_DIR:EDM4HEP::edm4hep>>:\
+$<$<TARGET_EXISTS:podio::podio>:$<TARGET_FILE_DIR:podio::podio>>:\
+$ENV{LD_LIBRARY_PATH};\
+PYTHONPATH=${PROJECT_SOURCE_DIR}/python:\
+${PROJECT_BINARY_DIR}/${PROJECT_NAME}/genConfDir:\
+/${PROJECT_NAME}/genConfDir:\
+$ENV{PYTHONPATH}")
+
 function(set_test_env testname)
-  set_property(TEST ${testname} APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}:${PROJECT_BINARY_DIR}/${PROJECT_NAME}:${PROJECT_BINARY_DIR}/${PROJECT_NAME}/genConfDir/${PROJECT_NAME}:${PROJECT_BINARY_DIR}/test/k4FWCoreTest:${PROJECT_BINARY_DIR}/test/k4FWCoreTest/genConfDir/k4FWCoreTest:$<$<TARGET_EXISTS:ROOT::Core>:$<TARGET_FILE_DIR:ROOT::Core>>:$<$<TARGET_EXISTS:EDM4HEP::edm4hep>:$<TARGET_FILE_DIR:EDM4HEP::edm4hep>>:$<$<TARGET_EXISTS:podio::podio>:$<TARGET_FILE_DIR:podio::podio>>:$ENV{LD_LIBRARY_PATH}")
-  set_property(TEST ${testname} APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${PROJECT_SOURCE_DIR}/python:${PROJECT_BINARY_DIR}/${PROJECT_NAME}/genConfDir:/${PROJECT_NAME}/genConfDir:$ENV{PYTHONPATH}")
+  set_tests_properties(${testname} PROPERTIES ENVIRONMENT "${_test_environment}")
 endfunction()
 
 add_test(NAME "clone_CLDConfig"


### PR DESCRIPTION
BEGINRELEASENOTES
- Cleanup the test environment

ENDRELEASENOTES

The current test env seems to be copied from k4FWCore(?) and includes a bunch of things that don't need to be there
