### PR TITLE
Fix the `ClonesAndSplitTracksFinder` and increase its test coverage

### DIFF
--- a/k4Reco/Tracking/src/ClonesAndSplitTracksFinder.cpp
+++ b/k4Reco/Tracking/src/ClonesAndSplitTracksFinder.cpp
@@ -222,7 +222,7 @@ void ClonesAndSplitTracksFinder::filterClonesAndMergedTracks(
           if (it_trk != trackVecFinal.end()) { // if the track is already there, do nothing
             continue;
           }
-          trackVecFinal.push_back(bestTracksMultiConnections.at(0));
+          trackVecFinal.push_back(bestTracksMultiConnections.at(0).clone());
 
         } else { // multiple best tracks with the same track key
           continue;
@@ -240,8 +240,8 @@ void ClonesAndSplitTracksFinder::filterClonesAndMergedTracks(
           continue;
         }
         // otherwise store the two tracks
-        trackVecFinal.push_back(track_a);
-        trackVecFinal.push_back(track_b);
+        trackVecFinal.push_back(track_a.clone());
+        trackVecFinal.push_back(track_b.clone());
 
       } // end of mergeable tracks
     }

--- a/k4Reco/Tracking/src/ClonesAndSplitTracksFinder.cpp
+++ b/k4Reco/Tracking/src/ClonesAndSplitTracksFinder.cpp
@@ -139,7 +139,7 @@ ClonesAndSplitTracksFinder::removeClones(const edm4hep::TrackCollection& input_t
     int countClones = 0;
     const edm4hep::Track& track1 = input_track_col.at(iTrack);
 
-    for (size_t jTrack = iTrack + 1; jTrack < input_track_col.size(); ++jTrack) {
+    for (size_t jTrack = 0; jTrack < input_track_col.size(); ++jTrack) {
       const edm4hep::Track& track2 = input_track_col.at(jTrack);
 
       if (track1 != track2) {

--- a/k4Reco/Tracking/src/ClonesAndSplitTracksFinder.cpp
+++ b/k4Reco/Tracking/src/ClonesAndSplitTracksFinder.cpp
@@ -104,7 +104,10 @@ edm4hep::TrackCollection ClonesAndSplitTracksFinder::operator()(const edm4hep::T
     // mergeSplitTracks(trackVec, input_track_col, tracksWithoutClones);
   } else {
     debug() << " Not even try to merge tracks ..." << endmsg;
-    trackVec = std::move(tracksWithoutClones);
+    // convert subset collection to a normal collection
+    for (const edm4hep::Track& track : tracksWithoutClones) {
+      trackVec.push_back(track.clone());
+    }
   }
 
   return trackVec;
@@ -125,6 +128,7 @@ size_t ClonesAndSplitTracksFinder::overlappingHits(const edm4hep::Track& track1,
 edm4hep::TrackCollection
 ClonesAndSplitTracksFinder::removeClones(const edm4hep::TrackCollection& input_track_col) const {
   edm4hep::TrackCollection tracksWithoutClones;
+  tracksWithoutClones.setSubsetCollection(true);
   debug() << "ClonesAndSplitTracksFinder::removeClones " << endmsg;
 
   // loop over the input tracks
@@ -152,7 +156,7 @@ ClonesAndSplitTracksFinder::removeClones(const edm4hep::TrackCollection& input_t
     } // end second track loop
 
     if (countClones == 0) {
-      tracksWithoutClones.push_back(track1.clone());
+      tracksWithoutClones.push_back(track1);
     }
 
   } // end first track loop
@@ -181,7 +185,7 @@ void ClonesAndSplitTracksFinder::filterClonesAndMergedTracks(
         if (it_trk != trackVecFinal.end()) { // if the track is already there, do nothing
           continue;
         }
-        trackVecFinal.push_back(track_final.clone());
+        trackVecFinal.push_back(track_final);
       } else { // mergeable tracks: compare the sets of tracker hits
 
         const auto& track_final_hits = track_final.getTrackerHits();
@@ -196,7 +200,7 @@ void ClonesAndSplitTracksFinder::filterClonesAndMergedTracks(
 
         if (toBeSaved) {
           savedHitVec.push_back(track_final_hits);
-          trackVecFinal.push_back(track_final.clone());
+          trackVecFinal.push_back(track_final);
         }
       }
 
@@ -211,6 +215,7 @@ void ClonesAndSplitTracksFinder::filterClonesAndMergedTracks(
                          // std::pair<std::multimap<edm4hep::Track*,std::pair<edm4hep::Track*,edm4hep::Track*>>::iterator,
                          // std::multimap<edm4hep::Track*,std::pair<edm4hep::Track*,edm4hep::Track*>>::iterator> ]
         edm4hep::TrackCollection bestTracksMultiConnections;
+        bestTracksMultiConnections.setSubsetCollection(true);
         for (auto it = ret.first; it != ret.second; ++it) {
           edm4hep::Track track_best = it->second.second;
           bestTracksMultiConnections.push_back(track_best);
@@ -222,7 +227,7 @@ void ClonesAndSplitTracksFinder::filterClonesAndMergedTracks(
           if (it_trk != trackVecFinal.end()) { // if the track is already there, do nothing
             continue;
           }
-          trackVecFinal.push_back(bestTracksMultiConnections.at(0).clone());
+          trackVecFinal.push_back(bestTracksMultiConnections.at(0));
 
         } else { // multiple best tracks with the same track key
           continue;
@@ -240,8 +245,8 @@ void ClonesAndSplitTracksFinder::filterClonesAndMergedTracks(
           continue;
         }
         // otherwise store the two tracks
-        trackVecFinal.push_back(track_a.clone());
-        trackVecFinal.push_back(track_b.clone());
+        trackVecFinal.push_back(track_a);
+        trackVecFinal.push_back(track_b);
 
       } // end of mergeable tracks
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ add_test(NAME "clone_CLDConfig"
 set_tests_properties("clone_CLDConfig" PROPERTIES FIXTURES_SETUP CLDConfig)
 
 add_test(NAME "run_ddsim"
-  COMMAND bash -c "ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G --numberOfEvents 3 --outputFile sim.edm4hep.root --gun.energy '10*GeV' --gun.particle 'mu-' --gun.distribution uniform --gun.multiplicity 30 --gun.thetaMin='89*deg' --gun.thetaMax='91*deg' --gun.phiMin='89*deg' --gun.phiMax='91*deg'"
+  COMMAND bash -c "ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G --numberOfEvents 3 --outputFile sim.edm4hep.root --gun.energy '10*GeV' --gun.particle 'mu-' --gun.distribution uniform --gun.multiplicity 10"
   )
 set_tests_properties("run_ddsim" PROPERTIES FIXTURES_SETUP SimOutput)
 
@@ -72,6 +72,18 @@ set_tests_properties("compare_LumiCalClusterer" PROPERTIES FIXTURES_REQUIRED "Wr
 
 if(BUILD_TRACKING)
 
+  add_test(NAME "run_ddsim_ClonesAndSplitTracksFinder"
+    COMMAND bash -c "ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G --numberOfEvents 3 --outputFile sim_clones_and_split_tracks_finder.edm4hep.root --gun.energy '10*GeV' --gun.particle 'mu-' --gun.distribution uniform --gun.multiplicity 30 --gun.thetaMin='89*deg' --gun.thetaMax='91*deg' --gun.phiMin='89*deg' --gun.phiMax='91*deg'"
+  )
+  set_tests_properties("run_ddsim_ClonesAndSplitTracksFinder" PROPERTIES FIXTURES_SETUP ClonesAndSplitTracksFinderSimOutput)
+
+  add_test(NAME "run_marlin_wrapper_ClonesAndSplitTracksFinder"
+    COMMAND k4run CLDReconstruction.py --inputFiles sim_clones_and_split_tracks_finder.edm4hep.root --trackingOnly --outputBasename output_clones_and_split_tracks_finder
+  )
+  set_tests_properties("run_marlin_wrapper_ClonesAndSplitTracksFinder" PROPERTIES
+    FIXTURES_REQUIRED "CLDConfig;ClonesAndSplitTracksFinderSimOutput"
+    FIXTURES_SETUP ClonesAndSplitTracksFinderWrapperOutput)
+
   add_test(NAME "run_ConformalTracking"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/options/runConformalTracking.py
   )
@@ -85,14 +97,14 @@ if(BUILD_TRACKING)
   set_tests_properties("compare_ConformalTracking" PROPERTIES FIXTURES_REQUIRED "ConformalTrackingOutput")
 
   add_test(NAME "run_ClonesAndSplitTracksFinder"
-    COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runClonesAndSplitTracksFinder.py
+    COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runClonesAndSplitTracksFinder.py --IOSvc.Input output_clones_and_split_tracks_finder_REC.edm4hep.root
   )
   set_tests_properties("run_ClonesAndSplitTracksFinder" PROPERTIES
-    FIXTURES_REQUIRED "WrapperOutput"
+    FIXTURES_REQUIRED "ClonesAndSplitTracksFinderWrapperOutput"
     FIXTURES_SETUP ClonesAndSplitTracksFinderOutput)
 
   add_test(NAME "compare_ClonesAndSplitTracksFinder"
-    COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --gaudi-file output_clones_and_split_tracks_finder.root --marlin-tracks SiTracks --gaudi-tracks GaudiSiTracks
+    COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --marlin-file output_clones_and_split_tracks_finder_REC.edm4hep.root --gaudi-file output_clones_and_split_tracks_finder.root --marlin-tracks SiTracks --gaudi-tracks GaudiSiTracks
   )
   set_tests_properties("compare_ClonesAndSplitTracksFinder" PROPERTIES FIXTURES_REQUIRED "ClonesAndSplitTracksFinderOutput")
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ add_test(NAME "clone_CLDConfig"
 set_tests_properties("clone_CLDConfig" PROPERTIES FIXTURES_SETUP CLDConfig)
 
 add_test(NAME "run_ddsim"
-  COMMAND bash -c "ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G --numberOfEvents 3 --outputFile sim.edm4hep.root --gun.energy '10*GeV' --gun.particle 'mu-' --gun.distribution uniform --gun.multiplicity 10"
+  COMMAND bash -c "ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G --numberOfEvents 3 --outputFile sim.edm4hep.root --gun.energy '10*GeV' --gun.particle 'mu-' --gun.distribution uniform --gun.multiplicity 30 --gun.thetaMin='89*deg' --gun.thetaMax='91*deg' --gun.phiMin='89*deg' --gun.phiMax='91*deg'"
   )
 set_tests_properties("run_ddsim" PROPERTIES FIXTURES_SETUP SimOutput)
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed the `ClonesAndSplitTracksFinder` and increased its test coverage 

ENDRELEASENOTES

While transitioning CLDConfig to the native algorithms for tracking (https://github.com/key4hep/CLDConfig/pull/70), we discovered some spurious test failures in the comparison of the number of reconstructed tracks.

I was able to trace them to the `ClonesAndSplitTracksFinder` and fix them. Essentially, all paths but the "no clones" path of the code were untested in this repository so far. In summary, I did the following:

1. I changed the settings on the particle gun to shoot a larger number of muons into a small angular area of the detector. This dit not result in the track number discrepancy that we saw before, but led to a crash of the code in the path dealing with multiple clones of a track, due to the storage of immutable/persisted tracks in an additional non-subset collection. (048857d4333ea15c1546a90567106b7c8a79d1bd)
2. I added the "fix" of cloning the tracks used in the single clone path (492d88ac30f00772cb4de5cf4f58e6086f9534d5). This leads to the algorithm running again and consistently showing the initially observed behaviour of not removing tracks.
3. I reverted 2. and introduced temporary subset collections everywhere, as otherwise, using the cloned copies of the tracks, the track-track comparisons in `filterClonesAndMergedTracks` always fail, resulting in all identified clones being added back to the track collection. (30a5a0f3adad6a7206be6abad29b1d960cefad10)
4. I restored the original logic of the naive all-to-all track comparison, as otherwise some tracks that are clones of other tracks are counted as having no clones themselves and thus added to the final collection. (1816d5ff05e3aba967661062059c3bb508894dfb)

In my tests, these changes restore identical behaviour to the corresponding Marlin processor, and all paths are hit. No special fixed seed was required, as the track environment seems to be dense enough :)

