### PR TITLE
Copy the test environment from k4FWCore

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,13 +23,11 @@ find_package(k4geo REQUIRED)
 add_test(NAME "clone_CLDConfig"
   COMMAND bash -c "if [ ! -d CLDConfig ]; then git clone https://github.com/key4hep/CLDConfig.git --depth 1; fi && cp -r CLDConfig/CLDConfig/* . && sed -i -e '/Overlay.Overlay/d' -e '/HighLevelReco.RecoMCTruthLink/d' CLDReconstruction.py"
 )
-set_test_env("clone_CLDConfig")
 set_tests_properties("clone_CLDConfig" PROPERTIES FIXTURES_SETUP CLDConfig)
 
 add_test(NAME "run_ddsim"
   COMMAND bash -c "ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G --numberOfEvents 3 --outputFile sim.edm4hep.root --gun.energy '10*GeV' --gun.particle 'mu-' --gun.distribution uniform --gun.multiplicity 10"
   )
-set_test_env("run_ddsim")
 set_tests_properties("run_ddsim" PROPERTIES FIXTURES_SETUP SimOutput)
 
 # If this is modified, make sure that this simulations produces clusters and reconstructed particles in the LumiCal
@@ -37,13 +35,11 @@ set_tests_properties("run_ddsim" PROPERTIES FIXTURES_SETUP SimOutput)
 add_test(NAME "run_ddsim_LumiCal"
   COMMAND bash -c "ddsim --compactFile $K4GEO/FCCee/CLD/compact/CLD_o2_v07/CLD_o2_v07.xml -G --numberOfEvents 3 --outputFile sim_lumical.edm4hep.root --gun.energy '50*GeV' --gun.particle 'gamma' --gun.distribution uniform --gun.multiplicity 10 --gun.thetaMin='50*mrad' --gun.thetaMax='100*mrad'"
   )
-set_test_env("run_ddsim_LumiCal")
 set_tests_properties("run_ddsim_LumiCal" PROPERTIES FIXTURES_SETUP SimLumiCalOutput)
 
 add_test(NAME "run_marlin_wrapper_truth_tracking"
   COMMAND k4run CLDReconstruction.py --inputFiles sim.edm4hep.root --trackingOnly --truthTracking --outputBasename output_truth_tracking
 )
-set_test_env("run_marlin_wrapper_truth_tracking")
 set_tests_properties("run_marlin_wrapper_truth_tracking" PROPERTIES
   FIXTURES_REQUIRED "CLDConfig;SimOutput"
   FIXTURES_SETUP TruthTrackingOutput)
@@ -51,7 +47,6 @@ set_tests_properties("run_marlin_wrapper_truth_tracking" PROPERTIES
 add_test(NAME "run_wrapper"
   COMMAND k4run CLDReconstruction.py --inputFiles sim.edm4hep.root --trackingOnly
 )
-set_test_env("run_wrapper")
 set_tests_properties("run_wrapper" PROPERTIES
   FIXTURES_REQUIRED "CLDConfig;SimOutput"
   FIXTURES_SETUP WrapperOutput)
@@ -59,7 +54,6 @@ set_tests_properties("run_wrapper" PROPERTIES
 add_test(NAME "run_wrapper_LumiCal"
   COMMAND k4run CLDReconstruction.py --inputFiles sim_lumical.edm4hep.root --outputBasename output_lumical
 )
-set_test_env("run_wrapper_LumiCal")
 set_tests_properties("run_wrapper_LumiCal" PROPERTIES
   FIXTURES_REQUIRED "CLDConfig;SimLumiCalOutput"
   FIXTURES_SETUP WrapperLumiCalOutput)
@@ -67,7 +61,6 @@ set_tests_properties("run_wrapper_LumiCal" PROPERTIES
 add_test(NAME "run_GaudiLumiCalClusterer"
   COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/GaudiLumiCalClusterer/options/runGaudiLumiCalClusterer.py --IOSvc.Input output_lumical_REC.edm4hep.root
 )
-set_test_env("run_GaudiLumiCalClusterer")
 set_tests_properties("run_GaudiLumiCalClusterer" PROPERTIES
   FIXTURES_REQUIRED "WrapperLumiCalOutput"
   FIXTURES_SETUP GaudiLumiCalOutput)
@@ -75,7 +68,6 @@ set_tests_properties("run_GaudiLumiCalClusterer" PROPERTIES
 add_test(NAME "compare_LumiCalClusterer"
   COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/GaudiLumiCalClusterer/scripts/compare-lumical.py"
 )
-set_test_env("compare_LumiCalClusterer")
 set_tests_properties("compare_LumiCalClusterer" PROPERTIES FIXTURES_REQUIRED "WrapperLumiCalOutput;GaudiLumiCalOutput")
 
 if(BUILD_TRACKING)
@@ -83,7 +75,6 @@ if(BUILD_TRACKING)
   add_test(NAME "run_ConformalTracking"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/options/runConformalTracking.py
   )
-  set_test_env("run_ConformalTracking")
   set_tests_properties("run_ConformalTracking" PROPERTIES
     FIXTURES_REQUIRED "WrapperOutput"
     FIXTURES_SETUP ConformalTrackingOutput)
@@ -91,13 +82,11 @@ if(BUILD_TRACKING)
   add_test(NAME "compare_ConformalTracking"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py"
   )
-  set_test_env("compare_ConformalTracking")
   set_tests_properties("compare_ConformalTracking" PROPERTIES FIXTURES_REQUIRED "ConformalTrackingOutput")
 
   add_test(NAME "run_ClonesAndSplitTracksFinder"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runClonesAndSplitTracksFinder.py
   )
-  set_test_env("run_ClonesAndSplitTracksFinder")
   set_tests_properties("run_ClonesAndSplitTracksFinder" PROPERTIES
     FIXTURES_REQUIRED "WrapperOutput"
     FIXTURES_SETUP ClonesAndSplitTracksFinderOutput)
@@ -105,13 +94,11 @@ if(BUILD_TRACKING)
   add_test(NAME "compare_ClonesAndSplitTracksFinder"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --gaudi-file output_clones_and_split_tracks_finder.root --marlin-tracks SiTracks --gaudi-tracks GaudiSiTracks
   )
-  set_test_env("compare_ClonesAndSplitTracksFinder")
   set_tests_properties("compare_ClonesAndSplitTracksFinder" PROPERTIES FIXTURES_REQUIRED "ClonesAndSplitTracksFinderOutput")
 
   add_test(NAME "run_RefitFinal"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runRefitFinal.py
   )
-  set_test_env("run_RefitFinal")
   set_tests_properties("run_RefitFinal" PROPERTIES
     FIXTURES_REQUIRED "WrapperOutput"
     FIXTURES_SETUP RefitFinalOutput)
@@ -119,13 +106,11 @@ if(BUILD_TRACKING)
   add_test(NAME "compare_RefitFinal"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --gaudi-file output_refit_final.root --marlin-tracks SiTracks_Refitted --gaudi-tracks GaudiSiTracks_Refitted
   )
-  set_test_env("compare_RefitFinal")
   set_tests_properties("compare_RefitFinal" PROPERTIES FIXTURES_REQUIRED "RefitFinalOutput")
 
   add_test(NAME "run_TruthTrackFinder"
     COMMAND k4run ${PROJECT_SOURCE_DIR}/k4Reco/Tracking/options/runTruthTrackFinder.py
   )
-  set_test_env("run_TruthTrackFinder")
   set_tests_properties("run_TruthTrackFinder" PROPERTIES
     FIXTURES_REQUIRED "TruthTrackingOutput"
     FIXTURES_SETUP TruthTrackFinderOutput)
@@ -133,7 +118,6 @@ if(BUILD_TRACKING)
   add_test(NAME "compare_TruthTrackFinder"
     COMMAND "${PROJECT_SOURCE_DIR}/k4Reco/ConformalTracking/scripts/compare-tracks.py" --marlin-file output_truth_tracking_REC.edm4hep.root --gaudi-file output_truth_track_finder.root --marlin-tracks SiTracks --gaudi-tracks GaudiSiTracks
   )
-  set_test_env("compare_TruthTrackFinder")
   set_tests_properties("compare_TruthTrackFinder" PROPERTIES FIXTURES_REQUIRED "TruthTrackFinderOutput")
 
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -123,7 +123,7 @@ if(BUILD_TRACKING)
 endif()
 
 
-get_filename_component(CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+get_filename_component(CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME) 
 
 set(test_environment "\
 LD_LIBRARY_PATH=\

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -123,7 +123,7 @@ if(BUILD_TRACKING)
 endif()
 
 
-get_filename_component(CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME) 
+get_filename_component(CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 
 set(test_environment "\
 LD_LIBRARY_PATH=\

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,18 +20,6 @@ limitations under the License.
 
 find_package(k4geo REQUIRED)
 
-set(_test_environment "\
-LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}:\
-${PROJECT_BINARY_DIR}/${PROJECT_NAME}:\
-$ENV{LD_LIBRARY_PATH};\
-PYTHONPATH=${PROJECT_SOURCE_DIR}/python:\
-${PROJECT_BINARY_DIR}/${PROJECT_NAME}/genConfDir:\
-$ENV{PYTHONPATH}")
-
-function(set_test_env testname)
-  set_tests_properties(${testname} PROPERTIES ENVIRONMENT "${_test_environment}")
-endfunction()
-
 add_test(NAME "clone_CLDConfig"
   COMMAND bash -c "if [ ! -d CLDConfig ]; then git clone https://github.com/key4hep/CLDConfig.git --depth 1; fi && cp -r CLDConfig/CLDConfig/* . && sed -i -e '/Overlay.Overlay/d' -e '/HighLevelReco.RecoMCTruthLink/d' CLDReconstruction.py"
 )
@@ -149,3 +137,31 @@ if(BUILD_TRACKING)
   set_tests_properties("compare_TruthTrackFinder" PROPERTIES FIXTURES_REQUIRED "TruthTrackFinderOutput")
 
 endif()
+
+
+get_filename_component(CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+
+set(test_environment "\
+LD_LIBRARY_PATH=\
+${PROJECT_BINARY_DIR}:\
+${PROJECT_BINARY_DIR}/${PROJECT_NAME}:\
+${CMAKE_CURRENT_BINARY_DIR}:\
+${CMAKE_CURRENT_BINARY_DIR}/genConfDir/${CURRENT_DIR_NAME}:\
+$ENV{LD_LIBRARY_PATH};\
+\
+GAUDI_PLUGIN_PATH=
+${PROJECT_BINARY_DIR}:\
+${PROJECT_BINARY_DIR}/${PROJECT_NAME}:\
+${CMAKE_CURRENT_BINARY_DIR}:\
+${CMAKE_CURRENT_BINARY_DIR}/genConfDir/${CURRENT_DIR_NAME}:\
+$ENV{GAUDI_PLUGIN_PATH}:\
+$ENV{LD_LIBRARY_PATH};\
+\
+PYTHONPATH=\
+${PROJECT_BINARY_DIR}/${PROJECT_NAME}/genConfDir:\
+${CMAKE_CURRENT_BINARY_DIR}/genConfDir:\
+$ENV{PYTHONPATH};\
+"
+)
+get_property(test_names DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY TESTS)
+set_tests_properties(${test_names} PROPERTIES ENVIRONMENT "${test_environment}")


### PR DESCRIPTION
BEGINRELEASENOTES
- Copy the test environment from k4FWCore, setting also `GAUDI_PLUGIN_PATH`

ENDRELEASENOTES

Eventually `GAUDI_PLUGIN_PATH` will be preferred. In the current version that is shipped in the stack, it's also looked up before `LD_LIBRARY_PATH`, preventing double loading of libraries and maybe fixing issues in https://github.com/key4hep/k4Reco/pull/59